### PR TITLE
Game design foundation: architecture, tooling, AI agents, and PokéRogue patterns

### DIFF
--- a/.claude/agents/battle-engine-tdd.md
+++ b/.claude/agents/battle-engine-tdd.md
@@ -1,0 +1,128 @@
+---
+name: battle-engine-tdd
+description: Test-driven development specialist for Cloud Quest's pure engine scripts — BattleEngine, SkillEngine, StatusEngine, EncounterEngine. Use when implementing or modifying any file in src/engine/. Writes tests first, then minimal implementation. Enforces zero Phaser dependency in all engine code.
+tools: [Read, Edit, Write, Bash]
+model: sonnet
+---
+
+You are a TDD specialist for Cloud Quest's engine layer. Your job: write tests first, then write the minimal implementation that passes them.
+
+## The Engine Layer Contract
+
+Files in `src/engine/` must satisfy ALL of these:
+
+1. **Zero Phaser imports** — if you can see `import Phaser` or `import { Scene }` anywhere, the file is wrong
+2. **Pure functions or classes** — no side effects beyond writing to `GameState`
+3. **Testable with plain Node.js** — no browser APIs, no canvas, no WebGL
+4. **Emit events, don't render** — return event arrays or call callbacks; never touch the DOM
+
+```js
+// Correct — pure function, testable
+export function calculateDamage(skillDomain, enemyDomain, basePower) {
+  const multiplier = getDomainMultiplier(skillDomain, enemyDomain)
+  return Math.floor(basePower * multiplier)
+}
+
+// Wrong — Phaser in engine
+import Phaser from 'phaser'
+export function calculateDamage(scene, skill, enemy) { ... }
+```
+
+## TDD Workflow
+
+1. Read the issue or feature spec
+2. Write failing tests that cover: happy path, edge cases, boundary values
+3. Run tests — confirm they fail for the right reason
+4. Write the minimal implementation to pass
+5. Run tests — confirm green
+6. Refactor if needed, tests must stay green
+
+```bash
+npm test              # run all tests
+npm run test:watch    # watch mode during development
+```
+
+## Domain Matchup System (memorise)
+
+```js
+const DOMAIN_MATCHUPS = {
+  linux:       { strong: 'security',   weak: 'kubernetes'  },
+  security:    { strong: 'serverless', weak: 'linux'       },
+  serverless:  { strong: 'cloud',      weak: 'security'    },
+  cloud:       { strong: 'iac',        weak: 'serverless'  },
+  iac:         { strong: 'containers', weak: 'cloud'       },
+  containers:  { strong: 'kubernetes', weak: 'iac'         },
+  kubernetes:  { strong: 'linux',      weak: 'containers'  },
+  observability: { strong: null, weak: null },
+}
+const STRONG_MULTIPLIER = 2.0
+const WEAK_MULTIPLIER   = 0.5
+```
+
+Test cases to always cover:
+- Strong domain → 2× damage
+- Weak domain → 0.5× damage
+- Neutral domain → 1× damage
+- Observability → 0 damage (support domain)
+- Cursed/nuclear (`domain: null`) → flat damage, ignores matchups
+
+## Solution Quality Test Cases
+
+```js
+// assess_quality(skill, opponent, domainRevealed) → 'optimal'|'standard'|'shortcut'|'cursed'|'nuclear'
+test('optimal: correct domain + domain was revealed first')
+test('standard: correct domain, domain was NOT revealed')
+test('shortcut: wrong domain, incident still resolved')
+test('cursed: skill.tier === cursed')
+test('nuclear: skill.tier === nuclear')
+```
+
+## BattleEvent Shape
+
+Every engine function returns an array of `BattleEvent` objects:
+
+```js
+{
+  type: 'damage' | 'heal' | 'status_apply' | 'status_remove'
+      | 'budget_drain' | 'shame' | 'dialog' | 'sla_tick'
+      | 'reveal' | 'win' | 'lose',
+  target: 'player' | 'opponent',
+  value: Number,
+  text: String,   // for 'dialog' type events
+}
+```
+
+Test that functions return arrays of valid BattleEvent objects — never undefined, never mutated state without an event.
+
+## SLA Timer Test Cases
+
+```js
+test('SLA timer decrements each turn')
+test('SLA breach fires when timer hits 0')
+test('SLA breach applies HP and reputation penalty')
+test('resolving incident before breach gives speed bonus')
+test('resolving after breach still wins but with penalties applied')
+```
+
+## Status Effect Test Cases
+
+For each status in `['throttled', 'cold_start', 'deprecated', 'on_call', 'cost_alert', 'technical_debt', 'in_review']`:
+```js
+test('status applies correctly')
+test('status ticks/decays each turn')
+test('status expires after duration')
+test('multiple statuses stack independently')
+```
+
+## What Good Test Output Looks Like
+
+```
+✓ calculateDamage — strong domain returns 2× base power
+✓ calculateDamage — weak domain returns 0.5× base power
+✓ calculateDamage — observability returns 0 damage
+✓ calculateDamage — cursed skill (domain: null) returns flat damage
+✓ assessQuality — optimal when domain revealed and correct
+✓ assessQuality — standard when domain not revealed
+✓ slaTimer — decrements each turn
+✓ slaTimer — fires breach event at 0
+```

--- a/.claude/agents/game-data-author.md
+++ b/.claude/agents/game-data-author.md
@@ -1,0 +1,119 @@
+---
+name: game-data-author
+description: Creates and validates skill, item, trainer, and emblem data definitions for Cloud Quest. Use when adding new content to src/data/ files. Ensures correct domain values, tier values, registry pattern exports, and cursed technique structure. Fast and precise — knows all valid field values by heart.
+tools: [Read, Edit, Write, Grep]
+model: haiku
+---
+
+You are a game data specialist for Cloud Quest. You create and validate content definitions in `src/data/`.
+
+## Your Rules
+
+- Data files contain ONLY plain object definitions. No logic, no conditionals, no imports from engine or scenes.
+- Every new entry must be added to both the `CONST` object AND appear in the module's exports.
+- IDs are always `snake_case` and must match the object key exactly.
+
+## Valid Field Values
+
+### Domains
+`linux` | `containers` | `kubernetes` | `cloud` | `security` | `iac` | `serverless` | `observability`
+
+### Tiers
+`optimal` | `standard` | `shortcut` | `cursed` | `nuclear`
+
+### Domain Matchup Cycle (memorise this)
+```
+linux → beats → security
+security → beats → serverless
+serverless → beats → cloud
+cloud → beats → iac
+iac → beats → containers
+containers → beats → kubernetes
+kubernetes → beats → linux
+observability → beats → nothing (support domain)
+```
+
+## Skill Definition Template
+
+```js
+skill_id: {
+  id: 'skill_id',
+  displayName: 'az webapp deploy',   // the actual CLI command, as typed
+  domain: 'cloud',
+  tier: 'optimal',
+  isCursed: false,
+  budgetCost: 0,
+  description: 'One sentence. Plain language. What it does in battle.',
+  effect: { type: 'damage', value: 30 },
+  sideEffect: null,
+  warningText: null,
+},
+```
+
+### For Cursed / Nuclear Techniques
+
+```js
+rm_rf: {
+  id: 'rm_rf',
+  displayName: 'rm -rf /',
+  domain: null,               // null — bypasses matchup system
+  tier: 'nuclear',
+  isCursed: true,
+  budgetCost: 0,
+  description: 'Wipes all status effects. Yours and the opponent\'s.',
+  effect: { type: 'status_clear', target: 'both' },
+  sideEffect: { type: 'reputation_damage', value: 30 },
+  warningText: 'This will work. But at what cost?',
+},
+```
+
+Cursed techniques always require: `domain: null`, `isCursed: true`, `sideEffect` not null, `warningText` not null.
+
+## Trainer Definition Template
+
+```js
+trainer_id: {
+  id: 'trainer_id',
+  name: 'Ola the Ops Guy',
+  domain: 'linux',
+  deck: ['systemctl_restart', 'grep_logs', 'chmod_fix'],
+  signatureSkill: 'systemctl_restart',  // taught on Optimal win
+  telegraphs: [
+    'Time to restart some services...',
+    'Let\'s see if you can read logs...',
+  ],
+  introDialog: 'You dare challenge the Ops Guy?',
+  winDialog: 'Not bad. Here — let me show you how systemctl works.',
+  loseDialog: 'Maybe read the man page next time.',
+  isCursedTrainer: false,
+  shameRequired: 0,
+  location: 'localhost_town',
+},
+```
+
+For cursed trainers: `isCursedTrainer: true`, `shameRequired: 2` (or higher), location is a hidden area ID.
+
+## Item Definition Template
+
+```js
+red_bull: {
+  id: 'red_bull',
+  name: 'Red Bull',
+  tab: 'tools',              // tools | keyItems | credentials | docs | junk
+  stackable: true,
+  description: '3am fuel. Restores 30 HP.',
+  effect: { type: 'heal', value: 30 },
+  useInBattle: true,
+},
+```
+
+## Validation Checklist
+
+Before submitting any new definition, verify:
+- [ ] `id` matches the object key exactly
+- [ ] `domain` is one of the 8 valid values (or `null` for cursed)
+- [ ] `tier` is one of the 5 valid values
+- [ ] Cursed techniques have `isCursed: true`, `domain: null`, `sideEffect` set, `warningText` set
+- [ ] `displayName` is the real CLI command (not a made-up name)
+- [ ] Registry exports at bottom of file include `getById`, `getAll`, `getBy`
+- [ ] No `import` from engine, scenes, or Phaser

--- a/.claude/agents/phaser-reviewer.md
+++ b/.claude/agents/phaser-reviewer.md
@@ -1,0 +1,97 @@
+---
+name: phaser-reviewer
+description: Reviews Phaser 3 scene and UI code for Cloud Quest. Use when a scene, UI component, or rendering file needs review. Checks engine/scene separation, GameState usage, pixel art compliance, and Phaser 3 best practices. Does NOT review engine scripts — those are pure JS and reviewed separately.
+tools: [Read, Grep]
+model: sonnet
+---
+
+You are a Phaser 3 code reviewer for Cloud Quest, a GameBoy Color-style browser RPG.
+
+## What You Review
+
+Files in: `src/scenes/`, `src/ui/`, `src/main.js`
+
+You do NOT review `src/engine/`, `src/data/`, or `src/state/` — those are pure JS with different rules.
+
+## Review Checklist
+
+### 1. Engine/Scene Separation (Critical)
+
+- [ ] No game logic in the scene — only rendering and event handling
+- [ ] All battle/encounter/skill logic delegated to engine classes
+- [ ] Scene only calls engine methods and renders the returned events
+- [ ] No direct manipulation of GameState from scenes — scenes call engines, engines write GameState
+
+```js
+// Correct — scene delegates to engine
+const events = this.battleEngine.useSkill(skillId)
+events.forEach(event => this.renderEvent(event))
+
+// Wrong — scene contains game logic
+if (skill.domain === opponent.domain) {
+  damage *= 2
+}
+```
+
+### 2. GameState Usage
+
+- [ ] Reads from `GameState` directly (not a local copy)
+- [ ] Never caches GameState values in scene properties across frames
+- [ ] Does not write to GameState directly — delegates to engines or SaveManager
+
+### 3. Phaser 3 API Correctness
+
+- [ ] Assets loaded in `preload()`, not `create()` or `update()`
+- [ ] `this.add.*` calls are in `create()`, not `update()`
+- [ ] `update()` only contains per-frame logic (input, movement, animation ticks)
+- [ ] Scene lifecycle methods present: `preload()`, `create()`, `update()`
+- [ ] Extends `BaseScene` (not `Phaser.Scene` directly) for shared utilities
+
+### 4. UI Components — Reuse Over Rebuild
+
+- [ ] Dialog text uses `DialogBox.js` — never raw Phaser text objects for game dialogue
+- [ ] Menu navigation uses `Menu.js` — never custom D-pad navigation reimplemented
+- [ ] HP/budget bars use `HUD.js` components
+
+### 5. Pixel Art Compliance
+
+- [ ] No `setAlpha()` tween animations — use frame swaps instead
+- [ ] No `setScale()` with non-integer values
+- [ ] No `tweens.add()` with position interpolation — movement is tile-snap only
+- [ ] Text uses Press Start 2P font only
+- [ ] No `setBlendMode()` effects that blur sprites
+
+### 6. Performance
+
+- [ ] No `new` object creation inside `update()` — pre-allocate in `create()`
+- [ ] Event listeners cleaned up in `shutdown()` or `destroy()`
+- [ ] No `setInterval` or `setTimeout` — use Phaser `time.addEvent()`
+
+## Common Issues to Flag
+
+**Wrong:**
+```js
+// Creating objects in update loop
+update() {
+  const text = this.add.text(0, 0, 'damage')  // allocates every frame
+}
+```
+
+**Correct:**
+```js
+create() {
+  this.damageText = this.add.text(0, 0, '').setVisible(false)
+}
+update() {
+  if (this.showDamage) this.damageText.setVisible(true).setText(this.damage)
+}
+```
+
+## Output Format
+
+For each issue found:
+1. File path and line number
+2. Rule violated (from checklist above)
+3. What the code does now
+4. What it should do instead
+5. Severity: Critical / Warning / Suggestion

--- a/.claude/skills/add-skill/SKILL.md
+++ b/.claude/skills/add-skill/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: add-skill
+description: Scaffold a new skill definition in src/data/skills.js. Invoke with the real CLI command to add (e.g. /add-skill "kubectl rollout restart").
+---
+
+You are adding a new skill to Cloud Quest's skill registry. Follow every rule below exactly.
+
+## What you need from the user
+
+- The real CLI command (e.g. `kubectl rollout restart deployment/api`)
+- The domain (pick from the table below, or ask if unclear)
+- The tier (pick from the table below, or ask if unclear)
+- Whether it should be cursed (if tier is `cursed` or `nuclear`, it must be)
+
+If any of those are missing from the invocation, ask before writing anything.
+
+---
+
+## Step 1 — Read the existing file
+
+Read `src/data/skills.js` in full before touching it. Note the last entry so you can append correctly.
+
+## Step 2 — Determine all field values
+
+Use these tables. No other values are valid.
+
+### Domain
+
+| Value | Beats | Weak against |
+|---|---|---|
+| `linux` | `security` | `kubernetes` |
+| `security` | `serverless` | `linux` |
+| `serverless` | `cloud` | `security` |
+| `cloud` | `iac` | `serverless` |
+| `iac` | `containers` | `cloud` |
+| `containers` | `kubernetes` | `iac` |
+| `kubernetes` | `linux` | `containers` |
+| `observability` | nothing | nothing (support — reveals info, 0 damage) |
+| `null` | bypasses matchup entirely (cursed/nuclear only) |
+
+### Tier
+
+| Value | XP mult | Rep | Shame | Notes |
+|---|---|---|---|---|
+| `optimal` | ×2 | +10 | 0 | Strong correct-domain technique |
+| `standard` | ×1 | +3 | 0 | Reasonable correct-domain technique |
+| `shortcut` | ×0.5 | −5 | 0 | Works but suboptimal |
+| `cursed` | ×0.25 | −15 | +1 | Forbidden — must set `isCursed: true`, `domain: null` |
+| `nuclear` | ×0 | −30 | +2 | Most destructive — must set `isCursed: true`, `domain: null` |
+
+### Effect types
+
+| Type | When to use |
+|---|---|
+| `damage` | Combat damage. Set `value` to base power (10–80). |
+| `reveal` | Observability skills only. `value: 0`. |
+| `heal` | Restores player HP. `value` = HP restored. |
+| `status_apply` | Applies a status effect to target. Add `status` field with status name. |
+| `buff_clear` | Removes buffs. Add `turns` and `target` fields. |
+| `status_clear` | Removes all statuses. Add `target: 'both' | 'player' | 'opponent'`. |
+
+## Step 3 — Write the entry
+
+Use this exact shape. Field order must match.
+
+### Standard / Optimal / Shortcut
+
+```js
+command_snake_case: {
+  id: 'command_snake_case',
+  displayName: 'actual cli command --flags',
+  domain: 'cloud',
+  tier: 'optimal',
+  isCursed: false,
+  budgetCost: 0,
+  description: 'One sentence. What it does in battle. Plain language.',
+  effect: { type: 'damage', value: 30 },
+  sideEffect: null,
+  warningText: null,
+},
+```
+
+### Observability (support)
+
+```js
+command_snake_case: {
+  id: 'command_snake_case',
+  displayName: 'actual cli command',
+  domain: 'observability',
+  tier: 'optimal',
+  isCursed: false,
+  budgetCost: 0,
+  description: 'Reveals enemy domain type and HP.',
+  effect: { type: 'reveal', value: 0 },
+  sideEffect: null,
+  warningText: null,
+},
+```
+
+### Cursed / Nuclear
+
+```js
+command_snake_case: {
+  id: 'command_snake_case',
+  displayName: 'actual cli command --dangerous-flag',
+  domain: null,
+  tier: 'cursed',
+  isCursed: true,
+  budgetCost: 0,
+  description: 'What it does. Be specific about collateral.',
+  effect: { type: 'damage', value: 60 },
+  sideEffect: { type: 'reputation_damage', value: 15 },
+  warningText: 'This will work. But at what cost?',
+},
+```
+
+## Step 4 — ID rules
+
+- `id` must be `snake_case` of the command, stripping flags
+- `id` must match the object key exactly
+- If a similar skill already exists, suffix with `_2` or use a more specific name
+- Example: `kubectl rollout restart` → `kubectl_rollout_restart`
+
+## Step 5 — Append to the file
+
+Add the new entry inside the `const SKILLS = { ... }` object, after the last existing entry.
+
+Do NOT touch the export block at the bottom. It must stay exactly as:
+
+```js
+export const getById = (id) => SKILLS[id]
+export const getAll  = () => Object.values(SKILLS)
+export const getBy   = (field, value) => getAll().filter(x => x[field] === value)
+```
+
+## Step 6 — Verify
+
+After writing, confirm:
+- [ ] `id` matches the object key
+- [ ] `domain` is a valid value from the table (or `null` for cursed)
+- [ ] `tier` is a valid value from the table
+- [ ] If `tier` is `cursed` or `nuclear`: `isCursed: true`, `domain: null`, `sideEffect` is not null, `warningText` is not null
+- [ ] `displayName` is the real CLI command as typed, not a description
+- [ ] Export block at bottom is unchanged

--- a/.claude/skills/add-trainer/SKILL.md
+++ b/.claude/skills/add-trainer/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: add-trainer
+description: Scaffold a new trainer definition in src/data/trainers.js. Invoke with the trainer concept (e.g. /add-trainer "Kubernetes specialist, mid-game, hostile").
+---
+
+You are adding a new trainer (NPC engineer battle opponent) to Cloud Quest. Follow every rule below exactly.
+
+## What you need from the user
+
+- The trainer concept or name
+- Their domain specialty (pick from valid domains below)
+- Their location (region or area ID)
+- Whether they are a cursed trainer (hidden area, shameRequired > 0)
+- Their deck of 3–5 skill IDs (must already exist in `src/data/skills.js`)
+
+If any are missing from the invocation, read `src/data/trainers.js` and `src/data/skills.js` first to get context, then ask.
+
+---
+
+## Step 1 — Read both files
+
+Read `src/data/trainers.js` and `src/data/skills.js` before writing anything. You need to:
+- Know which skill IDs exist to populate `deck`
+- Know the last trainer entry to append correctly
+
+## Step 2 — Determine field values
+
+### Valid domains
+
+`linux` | `containers` | `kubernetes` | `cloud` | `security` | `iac` | `serverless`
+
+Cursed trainers use `domain: null`.
+
+### Domain matchup cycle (for picking the right deck)
+
+```
+linux → beats → security
+security → beats → serverless
+serverless → beats → cloud
+cloud → beats → iac
+iac → beats → containers
+containers → beats → kubernetes
+kubernetes → beats → linux
+```
+
+A trainer's deck should contain skills matching their domain. The player needs to counter the trainer's domain.
+
+### Location IDs (known areas)
+
+`localhost_town` | `pipeline_pass` | `container_port` | `cloud_citadel` | `kernel_caves` | `serverless_steppes`
+
+Hidden/cursed areas: `three_am_tavern` | `legacy_codebase` | `outcast_network` | `shadow_registry`
+
+## Step 3 — Write the entry
+
+### Standard trainer
+
+```js
+trainer_id: {
+  id: 'trainer_id',
+  name: 'Full Display Name',
+  domain: 'kubernetes',
+  deck: ['kubectl_apply', 'kubectl_rollout_restart', 'kubectl_describe'],
+  signatureSkill: 'kubectl_apply',   // taught to player on Optimal win
+  telegraphs: [
+    'First line — foreshadows the move they are about to use.',
+    'Second line — alternate telegraph, used randomly.',
+    'Third line — optional, used for signature move.',
+  ],
+  introDialog: 'One to two sentences. Their personality. Why they fight.',
+  winDialog: 'What they say when player wins. What they teach or reveal.',
+  loseDialog: 'What they say when player loses. Should sting slightly.',
+  isCursedTrainer: false,
+  shameRequired: 0,
+  location: 'container_port',
+},
+```
+
+### Cursed trainer
+
+```js
+trainer_id: {
+  id: 'trainer_id',
+  name: 'Full Display Name',
+  domain: null,
+  deck: ['deploy_directly_to_prod', 'skip_tests_scroll'],
+  signatureSkill: 'deploy_directly_to_prod',
+  telegraphs: [
+    'No time for a pipeline...',
+    'Tests are just suggestions...',
+  ],
+  introDialog: 'They know you found them. They know what you\'ve done.',
+  winDialog: 'What forbidden knowledge they pass on.',
+  loseDialog: 'You\'re not reckless enough yet.',
+  isCursedTrainer: true,
+  shameRequired: 2,   // minimum shame to unlock this trainer
+  location: 'three_am_tavern',
+},
+```
+
+## Step 4 — ID rules
+
+- `id` must be `snake_case`, descriptive, unique
+- `id` must match the object key exactly
+- Format pattern: `{name}_{role}` e.g. `ola_ops_guy`, `hotfix_hakon`, `kube_master`
+
+## Step 5 — Dialog quality rules
+
+- `introDialog`: establish personality and stakes in 1–2 sentences; no question marks (trainers don't ask — they assert)
+- `winDialog`: teach something. Either reveals a technique, gives a hint, or unlocks a path. Never just "good game."
+- `loseDialog`: must sting. Short. Direct. Optionally gives a hint at what the player needs to learn.
+- `telegraphs`: 2–3 lines. Each foreshadows a specific move in the deck. The player should be able to pattern-match if paying attention.
+
+## Step 6 — Append to the file
+
+Add the new entry inside the `const TRAINERS = { ... }` object, after the last existing entry.
+
+Do NOT touch the export block at the bottom:
+
+```js
+export const getById = (id) => TRAINERS[id]
+export const getAll  = () => Object.values(TRAINERS)
+export const getBy   = (field, value) => getAll().filter(x => x[field] === value)
+```
+
+## Step 7 — Verify
+
+- [ ] `id` matches the object key
+- [ ] All skill IDs in `deck` exist in `src/data/skills.js`
+- [ ] `signatureSkill` is one of the skills in `deck`
+- [ ] `domain` is valid (or `null` for cursed trainers)
+- [ ] If `isCursedTrainer: true`: `shameRequired >= 2`, `domain: null`, location is a hidden area
+- [ ] `telegraphs` has at least 2 entries
+- [ ] All dialog fields are filled (no `null`, no empty string)
+- [ ] Export block is unchanged

--- a/.claude/skills/cloud-quest-battle/SKILL.md
+++ b/.claude/skills/cloud-quest-battle/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: cloud-quest-battle
+description: Complete reference for Cloud Quest's battle system. Use when implementing or modifying BattleEngine, SkillEngine, StatusEngine, BattleScene, or any battle-related logic. Covers domain matchups, solution quality, SLA timers, incident vs engineer modes, and shame/reputation mechanics.
+---
+
+# Cloud Quest Battle System Reference
+
+## Two Battle Modes
+
+### Incident Mode (wild encounters)
+The enemy is a technical problem — a 503 error, a CrashLoopBackOff, an Azure bill spike. The player must diagnose the root cause before the fix commands deal full damage.
+
+- Enemy domain type is hidden at start
+- Using an Observability command reveals it
+- Using the correct domain without reveal: 50% damage
+- Using the correct domain after reveal: full damage (×2 if strong match)
+- SLA timer counts down each turn — breach triggers penalties
+
+### Engineer Mode (trainer battles)
+Two skill decks. Both sides pick a command per turn. Domain matchups apply. The engineer telegraphs their next move one turn in advance.
+
+- Enemy deck defined in `TrainerData.deck`
+- Enemy telegraphs next move with a line from `TrainerData.telegraphs`
+- Win quality determines reward (see Solution Quality below)
+
+---
+
+## Domain Matchup System
+
+```js
+// src/config.js
+export const DOMAIN_MATCHUPS = {
+  linux:        { strong: 'security',   weak: 'kubernetes'  },
+  security:     { strong: 'serverless', weak: 'linux'       },
+  serverless:   { strong: 'cloud',      weak: 'security'    },
+  cloud:        { strong: 'iac',        weak: 'serverless'  },
+  iac:          { strong: 'containers', weak: 'cloud'       },
+  containers:   { strong: 'kubernetes', weak: 'iac'         },
+  kubernetes:   { strong: 'linux',      weak: 'containers'  },
+  observability: { strong: null, weak: null },
+}
+export const STRONG_MULTIPLIER = 2.0
+export const WEAK_MULTIPLIER   = 0.5
+```
+
+### Damage Calculation
+
+```js
+function calculateDamage(skillDomain, enemyDomain, basePower) {
+  if (skillDomain === null) return basePower  // cursed — flat, no matchup
+  if (skillDomain === 'observability') return 0  // support domain, no damage
+
+  const matchup = DOMAIN_MATCHUPS[skillDomain]
+  if (matchup.strong === enemyDomain) return Math.floor(basePower * STRONG_MULTIPLIER)
+  if (matchup.weak === enemyDomain)   return Math.floor(basePower * WEAK_MULTIPLIER)
+  return basePower  // neutral
+}
+```
+
+---
+
+## Solution Quality Assessment
+
+```js
+function assessQuality(skill, opponent, domainRevealed) {
+  if (skill.tier === 'nuclear')  return 'nuclear'
+  if (skill.tier === 'cursed')   return 'cursed'
+
+  const correctDomain = skill.domain === DOMAIN_MATCHUPS[skill.domain]?.strong
+    ? skill.domain : null  // simplified — actual logic checks against opponent domain
+
+  if (correctDomain && domainRevealed) return 'optimal'
+  if (correctDomain && !domainRevealed) return 'standard'
+  return 'shortcut'
+}
+```
+
+### Quality Rewards
+
+| Quality | XP mult | Rep delta | Shame delta | Engineer win reward |
+|---|---|---|---|---|
+| optimal | ×2 | +10 | 0 | Teaches signature skill |
+| standard | ×1 | +3 | 0 | Hints at related command |
+| shortcut | ×0.5 | −5 | 0 | Small XP only |
+| cursed | ×0.25 | −15 | +1 | No teaching, trainer leaves |
+| nuclear | ×0 | −30 | +2 | Trainer warns NPCs about player |
+
+---
+
+## SLA Timer
+
+Every incident has an `slaTimer` (turns remaining). Decrements each turn.
+
+```js
+function tickSla(state) {
+  state.slaTimer--
+  if (state.slaTimer <= 0 && !state.slaBreached) {
+    state.slaBreached = true
+    return [
+      { type: 'dialog', text: 'SLA BREACHED. You\'ll hear about this.' },
+      { type: 'damage', target: 'player', value: 20 },
+      { type: 'reputation_damage', target: 'player', value: 10 },
+    ]
+  }
+  return [{ type: 'sla_tick', value: state.slaTimer }]
+}
+```
+
+Resolving before breach gives an XP speed bonus. Resolving after breach still wins but with penalties already applied.
+
+---
+
+## BattleEvent Shape
+
+All engine functions return `BattleEvent[]`. BattleScene iterates and renders each.
+
+```js
+{
+  type: 'damage'         // hp loss
+      | 'heal'           // hp gain
+      | 'status_apply'   // status effect added
+      | 'status_remove'  // status effect expired
+      | 'budget_drain'   // budget loss
+      | 'shame'          // shame point added
+      | 'dialog'         // show text in battle log
+      | 'sla_tick'       // SLA countdown updated
+      | 'reveal'         // enemy domain revealed
+      | 'win'            // battle won
+      | 'lose',          // battle lost
+  target: 'player' | 'opponent',
+  value: Number,
+  text: String,          // for 'dialog' events only
+}
+```
+
+---
+
+## Status Effects
+
+```js
+const STATUSES = {
+  throttled:      { desc: 'Only 1 skill every 2 turns', duration: 3 },
+  cold_start:     { desc: 'Skip first turn of battle', duration: 1 },
+  deprecated:     { desc: 'Skills 50% effectiveness', duration: 4 },
+  on_call:        { desc: 'Random encounters after each battle', duration: 5 },
+  cost_alert:     { desc: 'Budget drains 2× faster', duration: 3 },
+  technical_debt: { desc: 'Max HP reduced by 2 per stack', duration: -1 }, // permanent until cleared
+  in_review:      { desc: 'Cannot act for 1–3 turns', duration: 'random' },
+}
+```
+
+---
+
+## Technical Debt (Cursed Technique Accumulation)
+
+Each cursed/nuclear technique use increments `GameState.player.technicalDebt` by 1 (capped at 10). Each stack permanently reduces `maxHp` by 2 until cleared by a cleanup quest.
+
+```js
+function applyTechnicalDebt(amount = 1) {
+  const newDebt = Math.min(GameState.player.technicalDebt + amount, 10)
+  GameState.player.technicalDebt = newDebt
+  GameState.player.maxHp = 100 - (newDebt * 2)
+  GameState.player.hp = Math.min(GameState.player.hp, GameState.player.maxHp)
+}
+```

--- a/.claude/skills/game-data-registry/SKILL.md
+++ b/.claude/skills/game-data-registry/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: game-data-registry
+description: Reference for adding new skills, items, trainers, and emblems to Cloud Quest's data layer. Use when creating new game content. Covers the registry pattern, all required fields, valid domain/tier values, and cursed technique structure.
+---
+
+# Game Data Registry — Cloud Quest
+
+## The Registry Pattern
+
+Every data module in `src/data/` must export these four functions. No exceptions.
+
+```js
+const SKILLS = {
+  // entries go here
+}
+
+export const getById = (id) => SKILLS[id]
+export const getAll  = () => Object.values(SKILLS)
+export const getBy   = (field, value) => getAll().filter(x => x[field] === value)
+```
+
+Never add a `find()`, `filter()`, or `Array.from()` call directly in game logic. Use `getBy()`.
+
+---
+
+## Adding a Skill (`src/data/skills.js`)
+
+### Standard / Optimal / Shortcut Skill
+
+```js
+az_webapp_deploy: {
+  id: 'az_webapp_deploy',
+  displayName: 'az webapp deploy',
+  domain: 'cloud',
+  tier: 'optimal',
+  isCursed: false,
+  budgetCost: 0,
+  description: 'Deploy to Azure App Service.',
+  effect: { type: 'damage', value: 30 },
+  sideEffect: null,
+  warningText: null,
+},
+```
+
+### Observability Skill (support domain — no damage)
+
+```js
+az_monitor_logs: {
+  id: 'az_monitor_logs',
+  displayName: 'az monitor logs',
+  domain: 'observability',
+  tier: 'optimal',
+  isCursed: false,
+  budgetCost: 0,
+  description: 'Pull Azure Monitor logs. Reveals enemy domain type and HP.',
+  effect: { type: 'reveal', value: 0 },
+  sideEffect: null,
+  warningText: null,
+},
+```
+
+### Cursed Technique
+
+```js
+git_push_force: {
+  id: 'git_push_force',
+  displayName: 'git push --force',
+  domain: null,           // null — bypasses domain matchup entirely
+  tier: 'cursed',
+  isCursed: true,
+  budgetCost: 0,
+  description: 'Wipe the opponent\'s last 3 turns of buffs. Side effects guaranteed.',
+  effect: { type: 'buff_clear', turns: 3, target: 'opponent' },
+  sideEffect: { type: 'buff_clear', turns: 1, target: 'player' },
+  warningText: 'This will work. But at what cost?',
+},
+```
+
+### Nuclear Technique
+
+```js
+rm_rf: {
+  id: 'rm_rf',
+  displayName: 'rm -rf /',
+  domain: null,
+  tier: 'nuclear',
+  isCursed: true,
+  budgetCost: 0,
+  description: 'Wipes all status effects — yours and theirs. Nothing survives.',
+  effect: { type: 'status_clear', target: 'both' },
+  sideEffect: { type: 'reputation_damage', value: 30 },
+  warningText: 'This will work. But at what cost?',
+},
+```
+
+### Valid Domain Values
+
+| Value | Beats | Weak against |
+|---|---|---|
+| `linux` | `security` | `kubernetes` |
+| `security` | `serverless` | `linux` |
+| `serverless` | `cloud` | `security` |
+| `cloud` | `iac` | `serverless` |
+| `iac` | `containers` | `cloud` |
+| `containers` | `kubernetes` | `iac` |
+| `kubernetes` | `linux` | `containers` |
+| `observability` | nothing | nothing |
+| `null` | — | bypasses matchup |
+
+### Valid Tier Values
+
+| Value | XP mult | Rep | Shame |
+|---|---|---|---|
+| `optimal` | ×2 | +++ | 0 |
+| `standard` | ×1 | + | 0 |
+| `shortcut` | ×0.5 | − | 0 |
+| `cursed` | ×0.25 | −− | +1 |
+| `nuclear` | ×0 | −−− | +2 |
+
+---
+
+## Adding a Trainer (`src/data/trainers.js`)
+
+```js
+ola_ops_guy: {
+  id: 'ola_ops_guy',
+  name: 'Ola the Ops Guy',
+  domain: 'linux',
+  deck: ['systemctl_restart', 'grep_logs', 'chmod_fix'],
+  signatureSkill: 'systemctl_restart',   // taught to player on Optimal win
+  telegraphs: [
+    'Time to restart some services...',
+    'Let\'s see what\'s in those logs...',
+  ],
+  introDialog: 'You dare challenge the Ops Guy? I\'ve been doing this since before containers existed.',
+  winDialog: 'Not bad. Let me show you how systemctl actually works.',
+  loseDialog: 'Read the man page. Then come back.',
+  isCursedTrainer: false,
+  shameRequired: 0,
+  location: 'localhost_town',
+},
+```
+
+### Cursed Trainer
+
+```js
+hotfix_hakon: {
+  id: 'hotfix_hakon',
+  name: 'Hotfix Håkon',
+  domain: null,
+  deck: ['deploy_directly_to_prod', 'skip_tests_scroll'],
+  signatureSkill: 'deploy_directly_to_prod',
+  telegraphs: [
+    'No time for a pipeline...',
+    'Tests are just suggestions...',
+  ],
+  introDialog: 'You found me. That means you\'ve made some choices. Same.',
+  winDialog: 'Fine. Here\'s how to deploy without the pipeline. Don\'t tell anyone.',
+  loseDialog: 'You\'re not ready to be this reckless.',
+  isCursedTrainer: true,
+  shameRequired: 2,
+  location: 'three_am_tavern',
+},
+```
+
+---
+
+## Adding an Item (`src/data/items.js`)
+
+```js
+red_bull: {
+  id: 'red_bull',
+  name: 'Red Bull',
+  tab: 'tools',             // tools | keyItems | credentials | docs | junk
+  stackable: true,
+  description: '3am fuel. Restores 30 HP.',
+  effect: { type: 'heal', value: 30 },
+  useInBattle: true,
+},
+
+terraform_state_file: {
+  id: 'terraform_state_file',
+  name: 'Terraform State File',
+  tab: 'docs',
+  stackable: false,
+  description: 'Don\'t touch it. Don\'t move it. Don\'t even look at it.',
+  effect: null,
+  useInBattle: false,
+},
+```

--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: implement-issue
+description: Implement a GitHub issue following Cloud Quest's architecture and conventions. Invoke with an issue number (e.g. /implement-issue 6).
+---
+
+You are implementing a GitHub issue for Cloud Quest. This skill enforces the project's architecture so implementations stay consistent.
+
+## Step 1 — Understand the issue
+
+Fetch the issue content. Read:
+- The issue title and body
+- Any referenced design issues (e.g. "See #41")
+- Labels (determines which layer to work in)
+
+Then read the relevant source files before writing any code.
+
+## Step 2 — Identify the layer
+
+| Label / location | Layer | Rules |
+|---|---|---|
+| `src/engine/` | Engine | Zero Phaser imports. Pure functions. Return `BattleEvent[]`. Unit tests required. |
+| `src/data/` | Data | Pure object definitions. No logic. Registry exports only. No imports from engine or scenes. |
+| `src/scenes/` | Scene | Phaser only. Delegates logic to engines. No game logic in scene. |
+| `src/ui/` | UI | Phaser components. Reusable. No game state mutation. |
+| `src/state/` | State | `GameState.js` only. Single mutable object. |
+
+## Step 3 — Engine layer implementation (if applicable)
+
+If the issue touches `src/engine/`, use TDD:
+
+1. Write tests first in the corresponding `tests/` file
+2. Run `npm test` — confirm tests fail
+3. Write minimal implementation
+4. Run `npm test` — confirm green
+5. Refactor only if tests stay green
+
+Engine code constraints:
+- No `import Phaser` anywhere in `src/engine/`
+- Functions return `BattleEvent[]` — never mutate state silently
+- All public functions must be exported
+
+```js
+// BattleEvent shape — every engine function returns these
+{
+  type: 'damage' | 'heal' | 'status_apply' | 'status_remove'
+      | 'budget_drain' | 'shame' | 'dialog' | 'sla_tick'
+      | 'reveal' | 'win' | 'lose',
+  target: 'player' | 'opponent',
+  value: Number,
+  text: String,   // 'dialog' type only
+}
+```
+
+Domain matchup system (implement exactly as specified):
+
+```js
+const DOMAIN_MATCHUPS = {
+  linux:       { strong: 'security',   weak: 'kubernetes'  },
+  security:    { strong: 'serverless', weak: 'linux'       },
+  serverless:  { strong: 'cloud',      weak: 'security'    },
+  cloud:       { strong: 'iac',        weak: 'serverless'  },
+  iac:         { strong: 'containers', weak: 'cloud'       },
+  containers:  { strong: 'kubernetes', weak: 'iac'         },
+  kubernetes:  { strong: 'linux',      weak: 'containers'  },
+  observability: { strong: null, weak: null },
+}
+const STRONG_MULTIPLIER = 2.0
+const WEAK_MULTIPLIER   = 0.5
+```
+
+## Step 4 — Data layer implementation (if applicable)
+
+If the issue adds skill/trainer/item data to `src/data/`:
+
+- Use `/add-skill` or `/add-trainer` skills for scaffolding
+- IDs are `snake_case`, must match object key
+- No logic, no conditionals, no imports from engine or scenes
+- Registry exports must remain at the bottom:
+
+```js
+export const getById = (id) => DATA[id]
+export const getAll  = () => Object.values(DATA)
+export const getBy   = (field, value) => getAll().filter(x => x[field] === value)
+```
+
+## Step 5 — Scene layer implementation (if applicable)
+
+If the issue touches `src/scenes/`:
+
+- Extend `BaseScene`
+- All game logic goes through engine calls — never inline calculations
+- Use `DialogBox` for all in-game dialogue (never raw Phaser text)
+- Read `GameState` fresh each frame — never cache across frames
+- Use `fadeToScene()` for transitions — never `this.scene.start()` in gameplay
+- Pixel art compliance (non-negotiable):
+  - No tweens on `x`, `y`, `scaleX`, `scaleY` — use frame swaps
+  - No non-integer scale values
+  - No `setAlpha()` transitions — hide/show is instant
+  - All text uses `{ fontFamily: CONFIG.FONT }`
+
+```js
+// Correct pattern: engine call → render events
+onSkillSelected(skillId) {
+  const events = this.engine.useSkill(skillId)
+  events.forEach(event => this.renderEvent(event))
+}
+```
+
+## Step 6 — GameState access
+
+Read directly from `GameState`. Never copy values to local variables that persist across frames.
+
+```js
+// Correct
+update() { this.hud.setHp(GameState.player.hp, GameState.player.maxHp) }
+
+// Wrong — stale after GameState changes
+create() { this.cachedHp = GameState.player.hp }
+```
+
+## Step 7 — Code quality rules
+
+- No defensive programming for internal code paths — only validate at system boundaries (user input, external APIs)
+- No helper abstractions for one-off operations — inline is fine
+- No feature flags, no backwards-compat shims
+- No added docstrings, comments, or type annotations on code you didn't change
+- Only add comments where the logic is genuinely non-obvious
+
+## Step 8 — Commit
+
+When the implementation is complete and tests pass:
+
+1. Stage only the files you changed
+2. Write a concise commit message: what changed and why (reference the issue number)
+3. Push to the development branch
+
+```bash
+git add src/engine/BattleEngine.js tests/BattleEngine.test.js
+git commit -m "Implement domain matchup damage calculation (#6)"
+git push -u origin claude/resolve-game-design-lFNI3
+```
+
+## Step 9 — Verify
+
+Before reporting done:
+- [ ] `npm test` passes (if engine code was changed)
+- [ ] No Phaser imports in `src/engine/`
+- [ ] No game logic in scenes
+- [ ] No logic in `src/data/`
+- [ ] Registry exports unchanged in data files
+- [ ] Pixel art compliance checklist cleared (if scene was changed)
+- [ ] Commit pushed to branch

--- a/.claude/skills/phaser-scene-patterns/SKILL.md
+++ b/.claude/skills/phaser-scene-patterns/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: phaser-scene-patterns
+description: Reference for correctly structuring Phaser 3 scenes in Cloud Quest. Use when implementing a new scene or modifying an existing one. Covers scene lifecycle, engine delegation, GameState access, DialogBox usage, and pixel art compliance.
+---
+
+# Phaser Scene Patterns — Cloud Quest
+
+## Scene Lifecycle
+
+Every scene in Cloud Quest follows this structure:
+
+```js
+import { BaseScene } from './BaseScene.js'
+import { BattleEngine } from '../engine/BattleEngine.js'
+import { GameState } from '../state/GameState.js'
+
+export class BattleScene extends BaseScene {
+  constructor() {
+    super({ key: 'BattleScene' })
+  }
+
+  preload() {
+    // Load assets here only. Nothing else.
+    this.load.spritesheet('player', 'assets/sprites/player.png', { frameWidth: 16, frameHeight: 24 })
+  }
+
+  create(data) {
+    // Receive data passed from previous scene
+    // Set up engine instances
+    // Create all display objects
+    // Register input handlers
+    this.engine = new BattleEngine(GameState.player, data.opponent)
+    this.engine.on('event', this.onBattleEvent, this)
+  }
+
+  update(time, delta) {
+    // Per-frame logic only: input polling, movement, animation ticks
+    // Never create objects here
+  }
+
+  shutdown() {
+    // Clean up event listeners
+    this.engine.off('event', this.onBattleEvent, this)
+  }
+}
+```
+
+## Delegating to Engines (Critical)
+
+Scenes receive player input and pass it to the engine. The engine returns events. The scene renders those events. No game logic in scenes.
+
+```js
+// Correct
+onSkillSelected(skillId) {
+  const events = this.engine.useSkill(skillId)
+  this.renderEvents(events)
+}
+
+renderEvents(events) {
+  events.forEach(event => {
+    switch (event.type) {
+      case 'damage':   this.showDamageNumber(event.target, event.value); break
+      case 'dialog':   this.dialogBox.show(event.text); break
+      case 'win':      this.scene.start('WorldScene'); break
+    }
+  })
+}
+
+// Wrong — game logic in scene
+onSkillSelected(skillId) {
+  const skill = getById(skillId)
+  if (skill.domain === this.opponent.domain) {  // ← logic belongs in SkillEngine
+    this.opponent.hp -= skill.effect.value * 2
+  }
+}
+```
+
+## Using DialogBox
+
+Never create raw Phaser text objects for in-game dialogue. Always use `DialogBox`:
+
+```js
+import { DialogBox } from '../ui/DialogBox.js'
+
+create() {
+  this.dialog = new DialogBox(this)  // pass scene reference
+
+  // Show a line of text
+  this.dialog.show('Professor Pedersen: "Choose wisely."')
+
+  // Show text with a callback when dismissed
+  this.dialog.show('Are you sure?', () => this.confirmAction())
+
+  // Show a choice menu
+  this.dialog.showChoices([
+    { label: 'az webapp deploy', action: () => this.useSkill('az_webapp_deploy') },
+    { label: 'rm -rf /', action: () => this.useSkill('rm_rf') },
+  ])
+}
+```
+
+## Reading GameState
+
+Read directly. Do not cache across frames.
+
+```js
+// Correct — read fresh each time
+update() {
+  this.hud.setHp(GameState.player.hp, GameState.player.maxHp)
+}
+
+// Wrong — stale reference if GameState changes mid-battle
+create() {
+  this.playerHp = GameState.player.hp  // cached, won't update
+}
+```
+
+## Scene Transitions
+
+Use `BaseScene.fadeToScene()` for all transitions. Never call `this.scene.start()` directly in gameplay code — it skips the fade.
+
+```js
+// Correct
+this.fadeToScene('WorldScene', { location: 'pipeline_pass' })
+
+// Only acceptable for immediate hard cuts (title screen, loading)
+this.scene.start('TitleScene')
+```
+
+## Pixel Art Compliance Checklist
+
+Before committing any scene:
+
+- [ ] No `tween` that interpolates `x`, `y`, `scaleX`, or `scaleY` — use frame swaps
+- [ ] No non-integer scale values (`setScale(1.5)` is forbidden)
+- [ ] No `setAlpha()` transitions — hide/show is instant
+- [ ] All text uses `{ fontFamily: CONFIG.FONT }` — no other font
+- [ ] All sprites have texture filter set to nearest (set globally in Phaser config, verify it wasn't overridden)
+
+## Passing Data Between Scenes
+
+```js
+// Launching a battle from WorldScene
+this.scene.launch('BattleScene', {
+  opponent: Registry.getTrainer('kube_master'),
+  mode: 'engineer',
+  returnScene: 'WorldScene',
+})
+this.scene.sleep('WorldScene')  // pause world, don't destroy it
+
+// In BattleScene — receive the data
+create(data) {
+  this.opponent = data.opponent
+  this.returnScene = data.returnScene
+}
+
+// After battle ends
+onBattleEnd(result) {
+  this.scene.stop('BattleScene')
+  this.scene.wake(this.returnScene)
+}
+```

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,122 @@
+# Cloud Quest — Phaser 3 Browser RPG
+
+A GameBoy Color-style RPG where the player is a cloud engineer using real CLI commands in turn-based battles. Phaser 3 + Vite, hosted on Azure Static Web Apps. No backend, no framework, fully stateless.
+
+---
+
+## Non-Negotiable Architecture Rules
+
+- **Engine scripts** (`src/engine/`) must never import Phaser. Pure JS logic, unit-testable with Node.js only.
+- **Scenes** (`src/scenes/`) delegate all logic to engines. They receive events and render them. No game logic in scenes.
+- **All mutable state** lives in `GameState.js`. Never store persistent state in a scene, engine instance, or module-level variable.
+- **Data modules** (`src/data/`) export pure object definitions only. No logic, no imports from engine or scenes.
+
+## Folder Purpose
+
+| Folder | Contains | Phaser allowed? |
+|---|---|---|
+| `src/state/` | GameState, SaveManager | No |
+| `src/data/` | Skills, items, trainers, quests, encounters | No |
+| `src/engine/` | BattleEngine, SkillEngine, StatusEngine, EncounterEngine | No |
+| `src/scenes/` | Phaser scenes — rendering only | Yes |
+| `src/ui/` | Reusable Phaser UI components (DialogBox, Menu, HUD) | Yes |
+| `src/utils/` | crypto, fileIO, random | No |
+
+## Data Registry Pattern
+
+All data modules (`src/data/*.js`) must follow this exact pattern — no exceptions:
+
+```js
+const SKILLS = {
+  az_webapp_deploy: { id: 'az_webapp_deploy', ...fields },
+}
+export const getById = (id) => SKILLS[id]
+export const getAll  = () => Object.values(SKILLS)
+export const getBy   = (field, value) => getAll().filter(x => x[field] === value)
+```
+
+Never iterate data arrays in game logic. Always use `getById()`.
+
+## Skill Fields
+
+Every entry in `src/data/skills.js`:
+
+```js
+{
+  id: 'az_webapp_deploy',          // snake_case, matches the object key
+  displayName: 'az webapp deploy', // the actual CLI command
+  domain: 'cloud',                 // see Domain Values below
+  tier: 'optimal',                 // see Tier Values below
+  isCursed: false,
+  budgetCost: 0,
+  description: 'Deploy to Azure App Service.',
+  effect: { type: 'damage', value: 30 },
+  sideEffect: null,                // cursed techniques only
+  warningText: null,               // shown before cursed technique use
+}
+```
+
+**Domain values:** `linux` `containers` `kubernetes` `cloud` `security` `iac` `serverless` `observability`
+
+**Tier values:** `optimal` `standard` `shortcut` `cursed` `nuclear`
+
+## Domain Matchup Cycle
+
+```
+Linux → Security → Serverless → Cloud → IaC → Containers → Kubernetes → Linux
+```
+
+Each domain deals ×2 damage to the domain it beats, ×0.5 to the domain that beats it, ×1 neutral otherwise. Observability deals no damage — it reveals enemy type and status.
+
+Defined in `src/config.js` as `DOMAIN_MATCHUPS`. Never hardcode multipliers inline.
+
+## Solution Quality Tiers
+
+| Tier | XP | Rep | Shame | When |
+|---|---|---|---|---|
+| optimal | ×2 | +++ | 0 | Correct domain, diagnosed first |
+| standard | ×1 | + | 0 | Correct domain, no diagnosis |
+| shortcut | ×0.5 | − | 0 | Wrong domain but worked |
+| cursed | ×0.25 | −− | +1 | Cursed technique used |
+| nuclear | ×0 | −−− | +2 | Nuclear technique used |
+
+## GameState Shape
+
+```js
+// src/state/GameState.js
+export const GameState = {
+  player: { name, level, xp, hp, maxHp, budget, reputation, shamePoints, technicalDebt, location, playtime },
+  skills: { active: [], learned: [], cursed: [] },
+  inventory: { tools: [], keyItems: [], credentials: [], docs: [], junk: [] },
+  emblems: {},
+  story: { act, completedQuests: [], flags: {} },
+  stats: { battlesWon, battlesLost, cursedTechniquesUsed, slaBreaches },
+  _session: { isDirty: false, lastSavedAt: null }
+}
+```
+
+`_session` is never written to the save file. Everything else is.
+
+## Visual Style
+
+- Canvas: 160×144px native, 640×576px display (4× integer scale, CSS `image-rendering: pixelated`)
+- Font: Press Start 2P only. No other fonts.
+- No smooth tweening. All animations are 2–4 frame sprite flips.
+- Max 56 colours total on screen. Max 4 colours per sprite.
+- Tile size: 16×16px. Player sprite: 16×24px.
+
+## Naming Conventions
+
+- Files: `camelCase.js`
+- Classes / scenes: `PascalCase`
+- Constants: `SCREAMING_SNAKE_CASE` defined in `src/config.js`
+- Data IDs: `snake_case` strings that match their object key
+
+## Do Not
+
+- Import Phaser in any `src/engine/` or `src/data/` file
+- Store state outside `GameState.js`
+- Iterate data arrays in game logic — use `getById()`
+- Add smooth tweens or sub-pixel movement
+- Hardcode domain names, tier names, or multiplier values — use `src/config.js`
+- Add logic to data files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ See `docs/sessions/2026-04-15-game-design.md` for the full design record and all
 | Tool | Purpose |
 |---|---|
 | **Phaser 3** | Game engine (HTML5 Canvas/WebGL) |
-| **Vite** | Dev server + bundler |
+| **Vite** | Dev server + bundler (with path aliases — see `vite.config.js`) |
 | **Vanilla JavaScript (ES modules)** | No framework |
 | **Azure Static Web Apps** | Hosting — free tier, custom headers |
 | **GitHub Actions** | CI/CD — build and deploy to Azure |
@@ -40,10 +40,12 @@ npm run preview   # Preview production build locally
 cloud-quest/
 ├── index.html                  # GameBoy Color shell (CSS border, buttons)
 ├── package.json                # vite + phaser
+├── vite.config.js              # Path aliases, dev server headers, build config
 ├── staticwebapp.config.json    # COOP/COEP headers for Azure Static Web Apps
 ├── src/
 │   ├── main.js                 # Phaser config + scene registry — nothing else
 │   ├── config.js               # Constants: resolution, palette, tile size, XP table
+│   ├── overrides.js            # Dev-only test overrides (shame, location, SLA, deck)
 │   │
 │   ├── state/
 │   │   ├── GameState.js        # Single mutable object — the only mutable state
@@ -55,14 +57,14 @@ cloud-quest/
 │   │   ├── trainers.js         # Good trainers + cursed trainers
 │   │   ├── quests.js           # Quest stages, rewards, flags
 │   │   ├── emblems.js          # Emblem metadata
-│   │   ├── encounters.js       # Encounter tables per region
+│   │   ├── encounters.js       # Pool-based encounter tables per region (common/rare/cursed)
 │   │   └── story.js            # Act definitions, flags, dialog trees
 │   │
 │   ├── engine/                 # Pure logic — no Phaser, fully unit-testable
-│   │   ├── BattleEngine.js     # Turn resolution, win condition, event log
+│   │   ├── BattleEngine.js     # Turn resolution, phase queue, win condition, event log
 │   │   ├── SkillEngine.js      # Skill effects, domain matchups, solution quality, XP
 │   │   ├── StatusEngine.js     # Status effect application + decay per turn
-│   │   └── EncounterEngine.js  # Encounter probability + selection per region
+│   │   └── EncounterEngine.js  # Encounter probability + pool selection per region
 │   │
 │   ├── scenes/                 # Phaser scenes — rendering only, delegate logic to engines
 │   │   ├── BaseScene.js        # Abstract base: showDialog(), fadeIn/Out(), playSound()
@@ -89,6 +91,7 @@ cloud-quest/
     ├── sprites/
     ├── maps/                   # Tiled .tmj exports
     └── audio/
+        └── bgm-loop-points.json  # Loop start/end times per track (seconds)
 ```
 
 ---
@@ -148,6 +151,85 @@ import Phaser from 'phaser'
 
 Scenes delegate all logic to engines. They receive events from engines and render them.
 
+### Path Aliases
+
+Import from these aliases — never use deep relative paths (`../../engine/...`).
+
+```js
+import { BattleEngine }  from '#engine/BattleEngine.js'
+import { getById }       from '#data/skills.js'
+import { GameState }     from '#state/GameState.js'
+import { DialogBox }     from '#ui/DialogBox.js'
+import { seededRandom }  from '#utils/random.js'
+```
+
+Aliases are defined in `vite.config.js` and map to `src/{name}/`.
+
+### Phase-Based Turn System
+
+Battle turns are not one monolithic function. Each discrete step is a **phase** — a function that returns a `BattleEvent[]` and optionally enqueues the next phase. `BattleEngine` owns a phase queue and iterates it.
+
+```js
+// Phases in a single player turn (order matters):
+// 1. StatusTickPhase   — tick/expire active status effects
+// 2. SkillPhase        — resolve the selected skill, calculate damage
+// 3. SlaTickPhase      — decrement SLA timer, fire breach event if 0
+// 4. EnemyPhase        — resolve enemy move (Engineer mode only)
+// 5. TurnEndPhase      — check win/lose conditions, award XP
+
+// Each phase returns BattleEvent[] — BattleScene renders them in order.
+// Never resolve two phases in one step. Never skip phases.
+```
+
+This makes turn logic testable in isolation: test `SlaTickPhase` without running `SkillPhase`.
+
+### Pool-Based Encounter Tables
+
+`encounters.js` organises enemies by rarity pool per region — not a flat list.
+
+```js
+localhost_town: {
+  common: ['503_error', 'npm_install_hang'],
+  rare:   ['infinite_loop', 'port_conflict'],
+  cursed: [],   // no cursed encounters in starting town
+},
+three_am_tavern: {
+  common: ['merge_conflict', 'missing_semicolon'],
+  rare:   ['prod_incident', 'runaway_process'],
+  cursed: ['sev1_at_3am'],
+},
+```
+
+`EncounterEngine` rolls against pool weights: common = 70%, rare = 25%, cursed = 5% (when available). The seeded RNG in `random.js` makes rolls reproducible from a given seed.
+
+### Audio — BGM Loop Points
+
+`assets/audio/bgm-loop-points.json` maps each track ID to `{ start, end }` in seconds. `BaseScene.playBgm(trackId)` reads this file to loop tracks seamlessly (avoiding the silent gap at the end of a file).
+
+```js
+// In BaseScene.js
+playBgm(trackId) {
+  const loop = BGM_LOOP_POINTS[trackId] ?? { start: 0, end: 0 }
+  // configure Phaser audio source with loop markers
+}
+```
+
+Fill in `start`/`end` values once tracks are finalized.
+
+### Dev Overrides
+
+`src/overrides.js` lets you bypass grinding during development. Values are null by default (no effect). Uncomment what you need; never commit uncommented overrides.
+
+```js
+// Test the evil path without accumulating 7 shame manually:
+SHAME_OVERRIDE: 7,
+
+// Test cursed area without navigating there:
+LOCATION_OVERRIDE: 'three_am_tavern',
+```
+
+`GameState.js` reads `Overrides` at startup in dev mode (`import.meta.env.DEV`).
+
 ---
 
 ## Key Design Decisions
@@ -170,6 +252,7 @@ Design issues: #41 (domain matchups) · #42 (solution tiers) · #43 (incidents) 
 
 - **Resolution**: 160×144px native, scaled 4× to 640×576px display
 - **Pixel scaling**: CSS `image-rendering: pixelated` on the canvas; no browser smoothing
+- **`antialias: false`** in the Phaser game config — non-negotiable, prevents WebGL blurring sprites
 - **Palette**: Max 56 colors total on screen; max 4 colors per sprite
 - **Font**: Press Start 2P (Google Fonts, free)
 - **No smooth tweening** — all animations are 2–4 frame sprite flips
@@ -183,6 +266,20 @@ export const CONFIG = {
   TILE_SIZE: 16,
   FONT: '"Press Start 2P"',
 }
+
+// src/main.js — Phaser game config (pixel-perfect enforcement)
+new Phaser.Game({
+  type: Phaser.AUTO,
+  width: CONFIG.WIDTH,
+  height: CONFIG.HEIGHT,
+  antialias: false,           // REQUIRED — never remove; prevents WebGL sprite blurring
+  pixelArt: true,             // Sets antialias false + roundPixels true
+  scale: {
+    mode: Phaser.Scale.FIT,   // Scales to window while preserving aspect ratio
+    autoCenter: Phaser.Scale.CENTER_BOTH,
+  },
+  scene: [ BootScene, TitleScene, WorldScene, BattleScene, /* ... */ ],
+})
 ```
 
 ---

--- a/assets/audio/bgm-loop-points.json
+++ b/assets/audio/bgm-loop-points.json
@@ -1,0 +1,25 @@
+{
+  "_note": "Loop points for seamless BGM looping. Values are in seconds. Set start/end to 0 for tracks that loop from the beginning.",
+
+  "title":              { "start": 0, "end": 0 },
+
+  "localhost_town":     { "start": 0, "end": 0 },
+  "pipeline_pass":      { "start": 0, "end": 0 },
+  "container_port":     { "start": 0, "end": 0 },
+  "cloud_citadel":      { "start": 0, "end": 0 },
+  "kernel_caves":       { "start": 0, "end": 0 },
+  "serverless_steppes": { "start": 0, "end": 0 },
+
+  "three_am_tavern":    { "start": 0, "end": 0 },
+  "legacy_codebase":    { "start": 0, "end": 0 },
+  "outcast_network":    { "start": 0, "end": 0 },
+  "shadow_registry":    { "start": 0, "end": 0 },
+
+  "battle_incident":    { "start": 0, "end": 0 },
+  "battle_engineer":    { "start": 0, "end": 0 },
+  "battle_cursed":      { "start": 0, "end": 0 },
+  "battle_throttlemaster": { "start": 0, "end": 0 },
+
+  "victory":            { "start": 0, "end": 0 },
+  "game_over":          { "start": 0, "end": 0 }
+}

--- a/src/overrides.js
+++ b/src/overrides.js
@@ -1,0 +1,62 @@
+/**
+ * Development overrides — for testing without grinding.
+ *
+ * Values here override their GameState equivalents at startup (dev only).
+ * The engine checks Overrides before GameState defaults during initialisation.
+ *
+ * NEVER commit uncommented overrides to main. This file is version-controlled
+ * so it documents every testable override — comments are the contract.
+ *
+ * Usage: imported by GameState.js in development builds only.
+ */
+
+export const Overrides = {
+
+  // --- Character state -------------------------------------------------
+
+  // Start with a specific shame count (unlock cursed trainers without grinding)
+  // SHAME_OVERRIDE: 7,
+
+  // Override reputation (0–100)
+  // REPUTATION_OVERRIDE: 50,
+
+  // Override technical debt stacks (0–10)
+  // TECHNICAL_DEBT_OVERRIDE: 0,
+
+  // Override HP and max HP
+  // HP_OVERRIDE: 100,
+
+  // Override level and XP
+  // LEVEL_OVERRIDE: null,
+
+  // --- World state -----------------------------------------------------
+
+  // Start at a specific location instead of Localhost Town
+  // LOCATION_OVERRIDE: 'three_am_tavern',
+
+  // Override act (story progression)
+  // ACT_OVERRIDE: null,
+
+  // Set story flags directly (merged onto story.flags at startup)
+  // FLAGS_OVERRIDE: {},
+
+  // --- Battle state ----------------------------------------------------
+
+  // Skip the SLA countdown in incident battles (never breaches)
+  // INFINITE_SLA: false,
+
+  // Force the enemy domain to be pre-revealed in incident mode
+  // DOMAIN_REVEALED_OVERRIDE: false,
+
+  // Force a specific opponent domain for testing matchups
+  // OPPONENT_DOMAIN_OVERRIDE: null,   // e.g. 'kubernetes'
+
+  // --- Inventory / skills ----------------------------------------------
+
+  // Start with this deck instead of the default starter deck
+  // STARTER_DECK: null,    // e.g. ['kubectl_apply', 'az_webapp_deploy', 'rm_rf']
+
+  // Start with these items in the bag
+  // STARTER_ITEMS: null,   // e.g. [{ id: 'red_bull', qty: 5 }]
+
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,27 @@
+import { defineConfig } from 'vite'
+import { resolve } from 'path'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '#engine': resolve('./src/engine'),
+      '#data':   resolve('./src/data'),
+      '#scenes': resolve('./src/scenes'),
+      '#state':  resolve('./src/state'),
+      '#ui':     resolve('./src/ui'),
+      '#utils':  resolve('./src/utils'),
+    },
+  },
+  server: {
+    port: 5173,
+    headers: {
+      // Required for SharedArrayBuffer and Phaser WebGL context isolation
+      'Cross-Origin-Opener-Policy': 'same-origin',
+      'Cross-Origin-Embedder-Policy': 'require-corp',
+    },
+  },
+  build: {
+    target: 'esnext',
+    chunkSizeWarningLimit: 1000,
+  },
+})


### PR DESCRIPTION
## Summary

Establishes the full development foundation for Cloud Quest following the 2026-04-15 game design session. Covers architecture decisions, AI tooling, and patterns borrowed from PokéRogue.

### Game design & project setup
- Replaced old ECC plugin files and README with Cloud Quest project README
- Rewrote CLAUDE.md for Phaser 3 (reversed earlier Godot migration)
- Added `staticwebapp.config.json` for Azure Static Web Apps COOP/COEP headers
- Added session memory at `docs/sessions/2026-04-15-game-design.md`

### Closed design gaps
- Closed #10 (Cloudémon companions) as `not_planned` — design pivoted to commands-as-skills
- Updated #39 (Pause Menu) — replaced "Cloudémon" slot with "Engineer Profile" showing Reputation, Shame, Technical Debt, and XP
- Closed Godot migration issues #51–#56 as `not_planned`

### AI development tooling (`.claude/` + `.github/`)
- **3 Claude Code agents**: `phaser-reviewer`, `game-data-author`, `battle-engine-tdd`
- **6 Claude Code skills**: `phaser-scene-patterns`, `game-data-registry`, `cloud-quest-battle`, `add-skill`, `add-trainer`, `implement-issue`
- **GitHub Copilot instructions** at `.github/copilot-instructions.md`

### PokéRogue-inspired architecture patterns
- `vite.config.js` — path aliases (`#engine`, `#data`, `#scenes`, `#state`, `#ui`, `#utils`)
- `src/overrides.js` — dev bypass file for testing shame, location, SLA, deck without grinding
- `assets/audio/bgm-loop-points.json` — loop point markers for seamless BGM looping
- CLAUDE.md: phase-based turn system, pool-based encounter tables, `antialias: false` in Phaser config, dev overrides pattern, BGM loop point contract

https://claude.ai/code/session_01QGyevoZY4zM8szk2szandY