### PR TITLE
fix: address all 10 Copilot review comments from PR #59

### DIFF
--- a/.claude/agents/battle-engine-tdd.md
+++ b/.claude/agents/battle-engine-tdd.md
@@ -84,7 +84,7 @@ Every engine function returns an array of `BattleEvent` objects:
 ```js
 {
   type: 'damage' | 'heal' | 'status_apply' | 'status_remove'
-      | 'budget_drain' | 'shame' | 'dialog' | 'sla_tick'
+      | 'budget_drain' | 'shame' | 'reputation_damage' | 'dialog' | 'sla_tick'
       | 'reveal' | 'win' | 'lose',
   target: 'player' | 'opponent',
   value: Number,

--- a/.claude/skills/cloud-quest-battle/SKILL.md
+++ b/.claude/skills/cloud-quest-battle/SKILL.md
@@ -116,20 +116,21 @@ All engine functions return `BattleEvent[]`. BattleScene iterates and renders ea
 
 ```js
 {
-  type: 'damage'         // hp loss
-      | 'heal'           // hp gain
-      | 'status_apply'   // status effect added
-      | 'status_remove'  // status effect expired
-      | 'budget_drain'   // budget loss
-      | 'shame'          // shame point added
-      | 'dialog'         // show text in battle log
-      | 'sla_tick'       // SLA countdown updated
-      | 'reveal'         // enemy domain revealed
-      | 'win'            // battle won
-      | 'lose',          // battle lost
+  type: 'damage'              // hp loss
+      | 'heal'                // hp gain
+      | 'status_apply'        // status effect added
+      | 'status_remove'       // status effect expired
+      | 'budget_drain'        // budget loss
+      | 'shame'               // shame point added
+      | 'reputation_damage'   // reputation loss (SLA breach, cursed technique)
+      | 'dialog'              // show text in battle log
+      | 'sla_tick'            // SLA countdown updated
+      | 'reveal'              // enemy domain revealed
+      | 'win'                 // battle won
+      | 'lose',               // battle lost
   target: 'player' | 'opponent',
   value: Number,
-  text: String,          // for 'dialog' events only
+  text: String,               // for 'dialog' events only
 }
 ```
 

--- a/.claude/skills/cloud-quest-battle/SKILL.md
+++ b/.claude/skills/cloud-quest-battle/SKILL.md
@@ -66,8 +66,8 @@ function assessQuality(skill, opponent, domainRevealed) {
   if (skill.tier === 'nuclear')  return 'nuclear'
   if (skill.tier === 'cursed')   return 'cursed'
 
-  const correctDomain = skill.domain === DOMAIN_MATCHUPS[skill.domain]?.strong
-    ? skill.domain : null  // simplified — actual logic checks against opponent domain
+  const correctDomain = skill.domain === DOMAIN_MATCHUPS[opponent.domain]?.weak
+    ? skill.domain : null  // skill's domain beats opponent's domain
 
   if (correctDomain && domainRevealed) return 'optimal'
   if (correctDomain && !domainRevealed) return 'standard'

--- a/.claude/skills/game-data-registry/SKILL.md
+++ b/.claude/skills/game-data-registry/SKILL.md
@@ -7,7 +7,7 @@ description: Reference for adding new skills, items, trainers, and emblems to Cl
 
 ## The Registry Pattern
 
-Every data module in `src/data/` must export these four functions. No exceptions.
+Every data module in `src/data/` must export these three functions. No exceptions.
 
 ```js
 const SKILLS = {

--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -43,7 +43,7 @@ Engine code constraints:
 // BattleEvent shape — every engine function returns these
 {
   type: 'damage' | 'heal' | 'status_apply' | 'status_remove'
-      | 'budget_drain' | 'shame' | 'dialog' | 'sla_tick'
+      | 'budget_drain' | 'shame' | 'reputation_damage' | 'dialog' | 'sla_tick'
       | 'reveal' | 'win' | 'lose',
   target: 'player' | 'opponent',
   value: Number,

--- a/.claude/skills/phaser-scene-patterns/SKILL.md
+++ b/.claude/skills/phaser-scene-patterns/SKILL.md
@@ -61,7 +61,7 @@ renderEvents(events) {
     switch (event.type) {
       case 'damage':   this.showDamageNumber(event.target, event.value); break
       case 'dialog':   this.dialogBox.show(event.text); break
-      case 'win':      this.scene.start('WorldScene'); break
+      case 'win':      this.fadeToScene('WorldScene'); break
     }
   })
 }
@@ -80,7 +80,7 @@ onSkillSelected(skillId) {
 Never create raw Phaser text objects for in-game dialogue. Always use `DialogBox`:
 
 ```js
-import { DialogBox } from '../ui/DialogBox.js'
+import { DialogBox } from '#ui/DialogBox.js'
 
 create() {
   this.dialog = new DialogBox(this)  // pass scene reference

--- a/.claude/skills/phaser-scene-patterns/SKILL.md
+++ b/.claude/skills/phaser-scene-patterns/SKILL.md
@@ -10,9 +10,9 @@ description: Reference for correctly structuring Phaser 3 scenes in Cloud Quest.
 Every scene in Cloud Quest follows this structure:
 
 ```js
-import { BaseScene } from './BaseScene.js'
-import { BattleEngine } from '../engine/BattleEngine.js'
-import { GameState } from '../state/GameState.js'
+import { BaseScene }    from '#scenes/BaseScene.js'
+import { BattleEngine } from '#engine/BattleEngine.js'
+import { GameState }    from '#state/GameState.js'
 
 export class BattleScene extends BaseScene {
   constructor() {

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,7 +9,7 @@ A GameBoy Color-style RPG where the player is a cloud engineer using real CLI co
 - **Engine scripts** (`src/engine/`) must never import Phaser. Pure JS logic, unit-testable with Node.js only.
 - **Scenes** (`src/scenes/`) delegate all logic to engines. They receive events and render them. No game logic in scenes.
 - **All mutable state** lives in `GameState.js`. Never store persistent state in a scene, engine instance, or module-level variable.
-- **Data modules** (`src/data/`) export pure object definitions only. No logic, no imports from engine or scenes.
+- **Data modules** (`src/data/`) contain no game logic or conditionals — only plain object definitions plus the three required registry accessors (`getById`, `getAll`, `getBy`). No imports from engine or scenes.
 
 ## Folder Purpose
 
@@ -107,7 +107,8 @@ export const GameState = {
 
 ## Naming Conventions
 
-- Files: `camelCase.js`
+- Files exporting a class: `PascalCase.js` — scenes, engines, UI components, state managers (e.g. `BattleEngine.js`, `BaseScene.js`, `DialogBox.js`, `GameState.js`)
+- Files exporting functions or data: `camelCase.js` — utils, data modules, config (e.g. `skills.js`, `random.js`, `config.js`)
 - Classes / scenes: `PascalCase`
 - Constants: `SCREAMING_SNAKE_CASE` defined in `src/config.js`
 - Data IDs: `snake_case` strings that match their object key

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,17 +218,17 @@ Fill in `start`/`end` values once tracks are finalized.
 
 ### Dev Overrides
 
-`src/overrides.js` lets you bypass grinding during development. Values are null by default (no effect). Uncomment what you need; never commit uncommented overrides.
+`src/overrides.js` lets you bypass grinding during development. Every override is commented out by default — uncomment what you need and recomment before committing. Never commit uncommented overrides to main.
 
 ```js
-// Test the evil path without accumulating 7 shame manually:
-SHAME_OVERRIDE: 7,
+// Uncomment to test the evil path without accumulating 7 shame manually:
+// SHAME_OVERRIDE: 7,
 
-// Test cursed area without navigating there:
-LOCATION_OVERRIDE: 'three_am_tavern',
+// Uncomment to test cursed area without navigating there:
+// LOCATION_OVERRIDE: 'three_am_tavern',
 ```
 
-`GameState.js` reads `Overrides` at startup in dev mode (`import.meta.env.DEV`).
+`GameState.js` reads `Overrides` at startup in dev mode (`import.meta.env.DEV`). Commented-out keys have no effect.
 
 ---
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,15 +1,19 @@
 import { defineConfig } from 'vite'
-import { resolve } from 'path'
+import { fileURLToPath } from 'url'
+import { dirname, resolve } from 'path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const src = (p) => resolve(__dirname, 'src', p)
 
 export default defineConfig({
   resolve: {
     alias: {
-      '#engine': resolve('./src/engine'),
-      '#data':   resolve('./src/data'),
-      '#scenes': resolve('./src/scenes'),
-      '#state':  resolve('./src/state'),
-      '#ui':     resolve('./src/ui'),
-      '#utils':  resolve('./src/utils'),
+      '#engine': src('engine'),
+      '#data':   src('data'),
+      '#scenes': src('scenes'),
+      '#state':  src('state'),
+      '#ui':     src('ui'),
+      '#utils':  src('utils'),
     },
   },
   server: {


### PR DESCRIPTION
Fixes all 10 issues raised by Copilot in the review of #59.

## Changes

**`reputation_damage` added to BattleEvent union** (3 files)
The event type was used in the SLA breach example but missing from the canonical type list in `cloud-quest-battle`, `implement-issue`, and `battle-engine-tdd`. Now consistent everywhere.

**`vite.config.js` — CWD-independent path aliases**
`resolve('./src/...')` depends on the working directory at execution time. Replaced with `fileURLToPath(import.meta.url)` + `dirname` so aliases are always anchored to the config file location.

**`game-data-registry` skill — "four functions" → "three functions"**
Only three exports are defined (`getById`, `getAll`, `getBy`). The copy said four.

**`CLAUDE.md` overrides documentation**
Said "values are null by default" but `src/overrides.js` uses commented-out keys. Corrected to accurately describe the "uncomment to enable" contract.

**`copilot-instructions.md` — "no logic" contradiction**
Data modules were described as "pure object definitions only, no logic" immediately followed by registry accessor functions. Reworded to "no game logic or conditionals — only data + registry accessors".

**`copilot-instructions.md` — naming convention**
Said `camelCase.js` for all files but the project uses PascalCase for class files (`BattleEngine.js`, `BaseScene.js`, etc.). Now documents the split: PascalCase for files exporting a class, camelCase for function/data files.

**`phaser-scene-patterns` skill — path aliases in examples**
Scene lifecycle example used deep relative imports (`../engine/BattleEngine.js`). Updated to use path aliases (`#engine/BattleEngine.js`, `#state/GameState.js`, `#scenes/BaseScene.js`).

https://claude.ai/code/session_01QGyevoZY4zM8szk2szandY