### PR TITLE
feat: battle engine + skill engine + battle scene (#6)

### DIFF
--- a/src/engine/BattleEngine.js
+++ b/src/engine/BattleEngine.js
@@ -93,7 +93,6 @@ export function skillPhase(state, skill) {
   const effect = skill.effect
 
   if (effect.type === 'damage') {
-    const opponentDomain = state.domainRevealed ? state.opponent.domain : null
     const dmg = calculateDamage(skill, state.opponent.domain) // always use true domain for calculation
     state.opponent.hp = Math.max(0, state.opponent.hp - dmg)
     events.push({ type: 'damage', target: 'opponent', value: dmg })

--- a/src/engine/BattleEngine.js
+++ b/src/engine/BattleEngine.js
@@ -1,0 +1,236 @@
+// BattleEngine.js — phase-based turn resolution, zero Phaser imports.
+// Owns the battle state and phase queue. Returns BattleEvent[] arrays.
+// Scenes delegate all logic here; they only render the returned events.
+
+import { calculateDamage, calculateXP, applyShameAndReputation } from './SkillEngine.js'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const BATTLE_MODES = {
+  INCIDENT: 'INCIDENT', // Wild encounter — SLA timer, hidden domain
+  ENGINEER: 'ENGINEER', // Trainer battle — enemy telegraphs next move
+}
+
+// Default SLA timer when none specified
+const DEFAULT_SLA_TIMER = 10
+
+// Penalty applied on SLA breach
+const SLA_BREACH_HP_PENALTY  = 20
+const SLA_BREACH_REP_PENALTY = 15
+
+// Approximate enemy base attack power (used in enemyPhase)
+const ENEMY_BASE_POWER = 15
+
+// ---------------------------------------------------------------------------
+// createBattleState
+// Initialises a fresh battle state. This is the only mutable object in the
+// engine — phases read and write it, then return events describing the delta.
+// ---------------------------------------------------------------------------
+export function createBattleState(mode, player, opponent, options = {}) {
+  return {
+    mode,
+    turn:             1,
+    player:           { ...player },
+    opponent:         { ...opponent },
+    playerStatuses:   [],
+    opponentStatuses: [],
+    domainRevealed:   mode === BATTLE_MODES.ENGINEER,
+    slaTimer:         mode === BATTLE_MODES.INCIDENT
+                        ? (options.slaTimer ?? DEFAULT_SLA_TIMER)
+                        : null,
+    telegraphedMove:  options.telegraphedMove ?? null,
+    slaBreach:        false,
+    winningTier:      options.winningTier ?? null,
+    log:              [],
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1: StatusTickPhase
+// Decrements duration of all active player and opponent statuses.
+// Permanent statuses (duration === -1) are never decremented.
+// Expired statuses are removed and emit status_remove events.
+// ---------------------------------------------------------------------------
+export function statusTickPhase(state) {
+  const events = []
+
+  const tickStatuses = (statuses, target) => {
+    const toRemove = []
+    for (const status of statuses) {
+      if (status.duration === -1) continue // permanent
+      status.duration -= 1
+      events.push({ type: 'status_tick', target, value: status.duration, statusName: status.name })
+      if (status.duration <= 0) {
+        toRemove.push(status.name)
+        events.push({ type: 'status_remove', target, statusName: status.name })
+      }
+    }
+    // Remove expired
+    for (const name of toRemove) {
+      const idx = statuses.findIndex(s => s.name === name)
+      if (idx !== -1) statuses.splice(idx, 1)
+    }
+  }
+
+  tickStatuses(state.playerStatuses,   'player')
+  tickStatuses(state.opponentStatuses, 'opponent')
+
+  return events
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2: SkillPhase
+// Resolves the player's chosen skill.
+// Emits skill_used, damage/heal/domain_reveal, and reputation events.
+// ---------------------------------------------------------------------------
+export function skillPhase(state, skill) {
+  const events = []
+
+  events.push({ type: 'skill_used', target: 'opponent', skillId: skill.id })
+
+  const effect = skill.effect
+
+  if (effect.type === 'damage') {
+    const opponentDomain = state.domainRevealed ? state.opponent.domain : null
+    const dmg = calculateDamage(skill, state.opponent.domain) // always use true domain for calculation
+    state.opponent.hp = Math.max(0, state.opponent.hp - dmg)
+    events.push({ type: 'damage', target: 'opponent', value: dmg })
+  }
+
+  if (effect.type === 'heal') {
+    const healed = Math.min(effect.value, state.player.maxHp - state.player.hp)
+    state.player.hp = Math.min(state.player.maxHp, state.player.hp + effect.value)
+    events.push({ type: 'heal', target: 'player', value: healed })
+  }
+
+  if (effect.type === 'reveal_domain' || effect.type === 'reveal_and_tag_weakness') {
+    state.domainRevealed = true
+    events.push({ type: 'domain_reveal', target: 'opponent', value: state.opponent.domain })
+  }
+
+  // Cursed/nuclear side effects — shame and reputation
+  if (skill.isCursed || skill.tier === 'cursed' || skill.tier === 'nuclear') {
+    const updated = applyShameAndReputation(state.player, skill)
+    const shameDelta = updated.shamePoints - state.player.shamePoints
+    const repDelta   = updated.reputation  - state.player.reputation
+    state.player.shamePoints = updated.shamePoints
+    state.player.reputation  = updated.reputation
+    events.push({ type: 'reputation', target: 'player', value: repDelta, shameDelta })
+  }
+
+  return events
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3: SlaTickPhase
+// Decrements the SLA timer by 1 (INCIDENT mode only).
+// Fires sla_breach when the timer hits 0 and applies HP/rep penalties.
+// ---------------------------------------------------------------------------
+export function slaTickPhase(state) {
+  if (state.slaTimer === null) return []
+
+  const events = []
+
+  if (state.slaTimer <= 0) {
+    // Already breached — do not decrement further
+    return []
+  }
+
+  state.slaTimer -= 1
+  events.push({ type: 'sla_tick', value: state.slaTimer })
+
+  if (state.slaTimer === 0) {
+    state.slaBreach = true
+    state.player.hp         = Math.max(0, state.player.hp - SLA_BREACH_HP_PENALTY)
+    state.player.reputation = Math.max(0, state.player.reputation - SLA_BREACH_REP_PENALTY)
+    events.push({
+      type:            'sla_breach',
+      target:          'player',
+      value:           SLA_BREACH_HP_PENALTY,
+      reputationLoss:  SLA_BREACH_REP_PENALTY,
+    })
+  }
+
+  return events
+}
+
+// ---------------------------------------------------------------------------
+// Phase 4: EnemyPhase
+// Resolves enemy move.
+// - INCIDENT mode: no enemy turn (just environmental pressure via SLA).
+// - ENGINEER mode: enemy attacks the player.
+// ---------------------------------------------------------------------------
+export function enemyPhase(state) {
+  if (state.mode === BATTLE_MODES.INCIDENT) return []
+
+  const events = []
+  const moveId = state.telegraphedMove ?? 'basic_attack'
+
+  events.push({ type: 'skill_used', target: 'player', skillId: moveId })
+
+  // Enemy deals base power damage (simplified — domain matchup not applied here
+  // since enemy domain vs player is resolved by difficulty in full implementation)
+  const dmg = ENEMY_BASE_POWER
+  state.player.hp = Math.max(0, state.player.hp - dmg)
+  events.push({ type: 'damage', target: 'player', value: dmg })
+
+  return events
+}
+
+// ---------------------------------------------------------------------------
+// Phase 5: TurnEndPhase
+// Checks win/lose conditions and awards XP.
+// Win:  opponent.hp === 0
+// Lose: player.hp === 0 OR (slaBreach && opponent.hp > 0)
+// Also increments turn counter when battle continues.
+// ---------------------------------------------------------------------------
+export function turnEndPhase(state) {
+  const events = []
+
+  const opponentDefeated = state.opponent.hp <= 0
+  const playerDefeated   = state.player.hp <= 0
+  const slaLoss          = state.slaBreach && !opponentDefeated
+
+  if (opponentDefeated) {
+    const tier       = state.winningTier ?? 'standard'
+    const xp         = calculateXP(state.opponent.difficulty ?? 1, tier)
+    const hasTeach   = state.mode === BATTLE_MODES.ENGINEER && state.opponent.teachSkillId
+    events.push({ type: 'xp_gain',    target: 'player', value: xp })
+    if (hasTeach) {
+      events.push({ type: 'teach_skill', target: 'player', value: state.opponent.teachSkillId })
+    }
+    events.push({ type: 'battle_end', target: 'player', value: 'win' })
+    return events
+  }
+
+  if (playerDefeated || slaLoss) {
+    events.push({ type: 'battle_end', target: 'player', value: 'lose' })
+    return events
+  }
+
+  // Battle continues — increment turn
+  state.turn += 1
+  return events
+}
+
+// ---------------------------------------------------------------------------
+// resolveTurn
+// Runs all 5 phases in order and returns the concatenated BattleEvent[].
+// Phase order: StatusTick → Skill → SlaTick → Enemy → TurnEnd
+// ---------------------------------------------------------------------------
+export function resolveTurn(state, skill) {
+  const events = [
+    ...statusTickPhase(state),
+    ...skillPhase(state, skill),
+    ...slaTickPhase(state),
+    ...enemyPhase(state),
+    ...turnEndPhase(state),
+  ]
+
+  // Append all events to the battle log
+  state.log.push(...events)
+
+  return events
+}

--- a/src/engine/SkillEngine.js
+++ b/src/engine/SkillEngine.js
@@ -24,11 +24,12 @@ const REP_GAIN_STANDARD = 1
 //
 // Rules:
 //   - observability always returns 0 (support domain, no damage)
-//   - null skillDomain → cursed/nuclear bypass → 1.0 (flat)
 //   - null opponentDomain → unknown/hidden domain → 1.0 (neutral)
 //   - strong matchup → STRONG_MULTIPLIER (2.0)
 //   - weak matchup   → WEAK_MULTIPLIER   (0.5)
 //   - otherwise      → 1.0 (neutral)
+//
+// Note: cursed/nuclear bypass is handled in calculateDamage, not here.
 // ---------------------------------------------------------------------------
 export function getDomainMultiplier(skillDomain, opponentDomain) {
   if (skillDomain === 'observability') return 0
@@ -53,8 +54,10 @@ export function getDomainMultiplier(skillDomain, opponentDomain) {
 // ---------------------------------------------------------------------------
 export function calculateDamage(skill, opponentDomain) {
   if (!skill?.effect || skill.effect.type !== 'damage') return 0
-  const base       = skill.effect.value ?? 0
-  const multiplier = getDomainMultiplier(skill.domain, opponentDomain)
+  const base = skill.effect.value ?? 0
+  // Cursed/nuclear skills bypass domain matchups — always deal flat ×1.0 damage.
+  const isBypass = skill.isCursed || skill.tier === 'cursed' || skill.tier === 'nuclear'
+  const multiplier = isBypass ? 1.0 : getDomainMultiplier(skill.domain, opponentDomain)
   return Math.floor(base * multiplier)
 }
 

--- a/src/engine/SkillEngine.js
+++ b/src/engine/SkillEngine.js
@@ -1,0 +1,129 @@
+// SkillEngine.js — pure skill resolution logic, zero Phaser imports.
+// Handles domain matchups, damage calculation, XP, quality assessment,
+// and shame/reputation side effects.
+
+import { DOMAIN_MATCHUPS, STRONG_MULTIPLIER, WEAK_MULTIPLIER } from '../config.js'
+
+// XP multipliers per solution quality tier.
+const XP_MULTIPLIERS = {
+  optimal:  2,
+  standard: 1,
+  shortcut: 0.5,
+  cursed:   0.25,
+  nuclear:  0,
+}
+
+// Reputation gain for non-cursed skill use (per turn).
+const REP_GAIN_OPTIMAL  = 3
+const REP_GAIN_STANDARD = 1
+
+// ---------------------------------------------------------------------------
+// getDomainMultiplier
+// Returns the damage multiplier when a skill of `skillDomain` is used
+// against an opponent with `opponentDomain`.
+//
+// Rules:
+//   - observability always returns 0 (support domain, no damage)
+//   - null skillDomain → cursed/nuclear bypass → 1.0 (flat)
+//   - null opponentDomain → unknown/hidden domain → 1.0 (neutral)
+//   - strong matchup → STRONG_MULTIPLIER (2.0)
+//   - weak matchup   → WEAK_MULTIPLIER   (0.5)
+//   - otherwise      → 1.0 (neutral)
+// ---------------------------------------------------------------------------
+export function getDomainMultiplier(skillDomain, opponentDomain) {
+  if (skillDomain === 'observability') return 0
+  if (skillDomain === null || skillDomain === undefined) return 1.0
+  if (opponentDomain === null || opponentDomain === undefined) return 1.0
+
+  const matchup = DOMAIN_MATCHUPS[skillDomain]
+  if (!matchup) return 1.0
+
+  if (matchup.strong === opponentDomain) return STRONG_MULTIPLIER
+  if (matchup.weak   === opponentDomain) return WEAK_MULTIPLIER
+
+  return 1.0
+}
+
+// ---------------------------------------------------------------------------
+// calculateDamage
+// Returns the final integer damage dealt by `skill` against an opponent
+// whose domain is `opponentDomain`.
+//
+// Only skills with effect.type === 'damage' deal damage; all others return 0.
+// ---------------------------------------------------------------------------
+export function calculateDamage(skill, opponentDomain) {
+  if (!skill?.effect || skill.effect.type !== 'damage') return 0
+  const base       = skill.effect.value ?? 0
+  const multiplier = getDomainMultiplier(skill.domain, opponentDomain)
+  return Math.floor(base * multiplier)
+}
+
+// ---------------------------------------------------------------------------
+// calculateXP
+// Returns XP awarded after a battle win.
+// Formula: Math.floor(difficulty * 30 * MULTIPLIERS[tier])
+// Returns 0 for unknown tiers.
+// ---------------------------------------------------------------------------
+export function calculateXP(opponentDifficulty, winningTier) {
+  const multiplier = XP_MULTIPLIERS[winningTier]
+  if (multiplier === undefined) return 0
+  return Math.floor(opponentDifficulty * 30 * multiplier)
+}
+
+// ---------------------------------------------------------------------------
+// assessQuality
+// Determines solution quality: 'optimal' | 'standard' | 'shortcut' | 'cursed' | 'nuclear'
+//
+// Priority order (highest first):
+//   1. nuclear tier  → 'nuclear'
+//   2. cursed tier   → 'cursed'
+//   3. correct domain + domain was revealed first  → 'optimal'
+//   4. correct domain, domain NOT revealed          → 'standard'
+//   5. wrong domain, incident resolved (hp <= 0)   → 'shortcut'
+//   6. otherwise → 'standard'
+// ---------------------------------------------------------------------------
+export function assessQuality(skill, opponent, domainRevealed) {
+  if (skill.tier === 'nuclear') return 'nuclear'
+  if (skill.tier === 'cursed')  return 'cursed'
+
+  const multiplier = getDomainMultiplier(skill.domain, opponent.domain)
+  const isCorrectDomain = multiplier >= STRONG_MULTIPLIER
+
+  if (isCorrectDomain && domainRevealed) return 'optimal'
+  if (isCorrectDomain && !domainRevealed) return 'standard'
+
+  // Wrong domain but incident still resolved
+  if (opponent.hp !== undefined && opponent.hp <= 0) return 'shortcut'
+
+  return 'standard'
+}
+
+// ---------------------------------------------------------------------------
+// applyShameAndReputation
+// Returns a new player snapshot with updated shamePoints and reputation.
+// Does NOT mutate the original player object.
+//
+// Rules:
+//   - cursed/nuclear: apply sideEffect.shame and sideEffect.reputation
+//   - optimal: +REP_GAIN_OPTIMAL reputation (no shame)
+//   - standard/shortcut: +REP_GAIN_STANDARD reputation (no shame)
+//   - reputation is clamped to [0, 100]
+//   - shamePoints only increases, never decrements
+// ---------------------------------------------------------------------------
+export function applyShameAndReputation(player, skill) {
+  let { shamePoints, reputation } = player
+
+  if ((skill.tier === 'cursed' || skill.tier === 'nuclear') && skill.sideEffect) {
+    shamePoints += skill.sideEffect.shame ?? 0
+    reputation  += skill.sideEffect.reputation ?? 0
+  } else if (skill.tier === 'optimal') {
+    reputation += REP_GAIN_OPTIMAL
+  } else {
+    reputation += REP_GAIN_STANDARD
+  }
+
+  // Clamp reputation to [0, 100]
+  reputation = Math.max(0, Math.min(100, reputation))
+
+  return { ...player, shamePoints, reputation }
+}

--- a/src/scenes/BattleScene.js
+++ b/src/scenes/BattleScene.js
@@ -1,6 +1,6 @@
 import Phaser from 'phaser'
 import { BaseScene } from '#scenes/BaseScene.js'
-import { CONFIG, COLORS } from '../config.js'
+import { CONFIG } from '../config.js'
 import { GameState, markDirty } from '#state/GameState.js'
 import { getById as getSkillById } from '#data/skills.js'
 import {
@@ -8,28 +8,28 @@ import {
   createBattleState,
   resolveTurn,
 } from '#engine/BattleEngine.js'
-import { assessQuality } from '#engine/SkillEngine.js'
+import { assessQuality, calculateXP } from '#engine/SkillEngine.js'
 
 // ---------------------------------------------------------------------------
-// Layout constants (all in logical pixels at the game's native resolution)
+// Layout constants — positions derived from CONFIG.WIDTH/HEIGHT (160×144 native)
 // ---------------------------------------------------------------------------
-const ENEMY_HP_BAR_X   = 80
+const ENEMY_HP_BAR_X   = Math.floor(CONFIG.WIDTH / 2)
 const ENEMY_HP_BAR_Y   = 10
 const PLAYER_HP_BAR_X  = 4
-const PLAYER_HP_BAR_Y  = 100
+const PLAYER_HP_BAR_Y  = CONFIG.HEIGHT - 44
 const BUDGET_METER_X   = 4
-const BUDGET_METER_Y   = 112
-const SLA_TIMER_X      = 120
+const BUDGET_METER_Y   = CONFIG.HEIGHT - 32
+const SLA_TIMER_X      = CONFIG.WIDTH - 40
 const SLA_TIMER_Y      = 6
 const SKILL_MENU_X     = 4
-const SKILL_MENU_Y     = 82
+const SKILL_MENU_Y     = CONFIG.HEIGHT - 62
 const SKILL_MENU_H     = 14
-const HP_BAR_W         = 76
+const HP_BAR_W         = Math.floor(CONFIG.WIDTH * 0.475)
 const HP_BAR_H         = 4
-const BUDGET_BAR_W     = 60
+const BUDGET_BAR_W     = Math.floor(CONFIG.WIDTH * 0.375)
 const BUDGET_BAR_H     = 4
 const LOG_X            = 4
-const LOG_Y            = 68
+const LOG_Y            = CONFIG.HEIGHT - 76
 
 // ---------------------------------------------------------------------------
 // BattleScene
@@ -221,7 +221,8 @@ export class BattleScene extends BaseScene {
       this._refreshMenuHighlight()
     }
     if (Phaser.Input.Keyboard.JustDown(keys.down)) {
-      this._skillIndex = Math.min(this._activeSkills.length - 1, this._skillIndex + 1)
+      const lastIndex  = Math.max(0, this._activeSkills.length - 1)
+      this._skillIndex = Math.min(lastIndex, this._skillIndex + 1)
       this._refreshMenuCursor()
       this._refreshMenuHighlight()
     }
@@ -236,11 +237,13 @@ export class BattleScene extends BaseScene {
   _useSkill(skill) {
     if (!skill || this._animating) return
 
-    // Assess quality before the turn (opponent HP check after)
+    const events = resolveTurn(this._battleState, skill)
+
+    // Post-turn quality assessment — opponent.hp now reflects the actual outcome,
+    // enabling correct shortcut detection (wrong domain but incident resolved).
     const quality = assessQuality(skill, this._battleState.opponent, this._battleState.domainRevealed)
     this._battleState.winningTier = quality
 
-    const events = resolveTurn(this._battleState, skill)
     this._animateEvents(events)
   }
 
@@ -342,20 +345,30 @@ export class BattleScene extends BaseScene {
   // _onBattleEnd — sync GameState then return to world
   // -------------------------------------------------------------------------
   _onBattleEnd(result) {
-    const { player } = this._battleState
+    const { player, opponent } = this._battleState
 
     // Write engine state back to GameState
-    GameState.player.hp         = player.hp
-    GameState.player.reputation = player.reputation
+    GameState.player.hp          = player.hp
+    GameState.player.reputation  = player.reputation
     GameState.player.shamePoints = player.shamePoints
-    markDirty()
 
     if (result === 'win') {
       GameState.stats.battlesWon++
+
+      // Apply XP using the post-turn quality tier
+      const xp = calculateXP(opponent.difficulty ?? 1, this._battleState.winningTier ?? 'standard')
+      GameState.player.xp = (GameState.player.xp ?? 0) + xp
+
+      // Apply any skill taught by an engineer opponent
+      const teachEvent = this._battleState.log.slice().reverse().find(e => e.type === 'teach_skill')
+      if (teachEvent?.value && !GameState.skills.learned.includes(teachEvent.value)) {
+        GameState.skills.learned.push(teachEvent.value)
+      }
     } else {
       GameState.stats.battlesLost++
     }
 
+    markDirty()
     this._showLog(result === 'win' ? 'Victory!' : 'Defeated...')
     this.time.delayedCall(1200, () => {
       this.fadeToScene(this._returnScene ?? 'WorldScene')

--- a/src/scenes/BattleScene.js
+++ b/src/scenes/BattleScene.js
@@ -1,0 +1,393 @@
+import Phaser from 'phaser'
+import { BaseScene } from '#scenes/BaseScene.js'
+import { CONFIG, COLORS } from '../config.js'
+import { GameState, markDirty } from '#state/GameState.js'
+import { getById as getSkillById } from '#data/skills.js'
+import {
+  BATTLE_MODES,
+  createBattleState,
+  resolveTurn,
+} from '#engine/BattleEngine.js'
+import { assessQuality } from '#engine/SkillEngine.js'
+
+// ---------------------------------------------------------------------------
+// Layout constants (all in logical pixels at the game's native resolution)
+// ---------------------------------------------------------------------------
+const ENEMY_HP_BAR_X   = 80
+const ENEMY_HP_BAR_Y   = 10
+const PLAYER_HP_BAR_X  = 4
+const PLAYER_HP_BAR_Y  = 100
+const BUDGET_METER_X   = 4
+const BUDGET_METER_Y   = 112
+const SLA_TIMER_X      = 120
+const SLA_TIMER_Y      = 6
+const SKILL_MENU_X     = 4
+const SKILL_MENU_Y     = 82
+const SKILL_MENU_H     = 14
+const HP_BAR_W         = 76
+const HP_BAR_H         = 4
+const BUDGET_BAR_W     = 60
+const BUDGET_BAR_H     = 4
+const LOG_X            = 4
+const LOG_Y            = 68
+
+// ---------------------------------------------------------------------------
+// BattleScene
+// Phaser rendering layer for all battle encounters.
+// Delegates ALL logic to BattleEngine and SkillEngine — no damage math here.
+// ---------------------------------------------------------------------------
+export class BattleScene extends BaseScene {
+  constructor() {
+    super({ key: 'BattleScene' })
+    this._battleState  = null
+    this._skillIndex   = 0
+    this._eventQueue   = []
+    this._animating    = false
+    this._activeSkills = []
+  }
+
+  // -------------------------------------------------------------------------
+  // create(data)
+  // data shape:
+  //   mode:            BATTLE_MODES.INCIDENT | BATTLE_MODES.ENGINEER
+  //   opponent:        { id, name, domain, hp, maxHp, difficulty, teachSkillId? }
+  //   slaTimer:        number (INCIDENT only)
+  //   telegraphedMove: string (ENGINEER only)
+  //   returnScene:     scene key to resume after battle
+  // -------------------------------------------------------------------------
+  create(data = {}) {
+    const mode     = data.mode ?? BATTLE_MODES.INCIDENT
+    const opponent = data.opponent ?? {
+      id: 'stub_incident', name: 'Stub Incident',
+      domain: 'cloud', hp: 60, maxHp: 60, difficulty: 2,
+    }
+    this._returnScene  = data.returnScene ?? 'WorldScene'
+    this._activeSkills = GameState.skills.active
+      .filter(Boolean)
+      .map(id => getSkillById(id))
+      .filter(Boolean)
+
+    // Build engine-side state (pure logic, no Phaser)
+    this._battleState = createBattleState(mode, { ...GameState.player }, opponent, {
+      slaTimer:        data.slaTimer ?? 10,
+      telegraphedMove: data.telegraphedMove ?? null,
+    })
+
+    this._skillIndex = 0
+    this._animating  = false
+    this._eventQueue = []
+
+    this._buildHUD(mode, opponent)
+    this._buildSkillMenu()
+    this._buildLogBox()
+    this._setupInput()
+
+    if (mode === BATTLE_MODES.INCIDENT) {
+      this.playBgm('bgm_battle_incident')
+    } else {
+      this.playBgm('bgm_battle_engineer')
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // HUD — player HP, enemy HP, budget meter, SLA timer
+  // -------------------------------------------------------------------------
+  _buildHUD(mode, opponent) {
+    const textStyle = { fontFamily: CONFIG.FONT, fontSize: '6px', color: '#ffffff' }
+
+    // Enemy name + HP
+    this._enemyNameText = this.add.text(ENEMY_HP_BAR_X, ENEMY_HP_BAR_Y - 2, opponent.name ?? '???', textStyle)
+    this._enemyHpBarBg  = this.add.rectangle(ENEMY_HP_BAR_X, ENEMY_HP_BAR_Y + 6, HP_BAR_W, HP_BAR_H, 0x440000).setOrigin(0, 0)
+    this._enemyHpBar    = this.add.rectangle(ENEMY_HP_BAR_X, ENEMY_HP_BAR_Y + 6, HP_BAR_W, HP_BAR_H, 0x00cc44).setOrigin(0, 0)
+
+    // In ENGINEER mode, show domain; in INCIDENT mode show '???'
+    const domainLabel = mode === BATTLE_MODES.ENGINEER ? opponent.domain : '???'
+    this._enemyDomainText = this.add.text(ENEMY_HP_BAR_X, ENEMY_HP_BAR_Y + 12, `[${domainLabel}]`, {
+      ...textStyle, color: '#9bc5ff',
+    })
+
+    // In ENGINEER mode, show telegraphed move
+    if (mode === BATTLE_MODES.ENGINEER && this._battleState.telegraphedMove) {
+      this.add.text(4, 22, `Preparing: ${this._battleState.telegraphedMove}`, {
+        ...textStyle, color: '#ffe066',
+      })
+    }
+
+    // Player HP
+    this.add.text(PLAYER_HP_BAR_X, PLAYER_HP_BAR_Y - 2, 'HP', textStyle)
+    this._playerHpBarBg = this.add.rectangle(PLAYER_HP_BAR_X + 12, PLAYER_HP_BAR_Y + 2, HP_BAR_W, HP_BAR_H, 0x440000).setOrigin(0, 0)
+    this._playerHpBar   = this.add.rectangle(PLAYER_HP_BAR_X + 12, PLAYER_HP_BAR_Y + 2, HP_BAR_W, HP_BAR_H, 0x00cc44).setOrigin(0, 0)
+    this._playerHpText  = this.add.text(PLAYER_HP_BAR_X + HP_BAR_W + 14, PLAYER_HP_BAR_Y - 2, this._hpLabel(), textStyle)
+
+    // Budget meter
+    this.add.text(BUDGET_METER_X, BUDGET_METER_Y - 2, '$', textStyle)
+    this._budgetBarBg = this.add.rectangle(BUDGET_METER_X + 8, BUDGET_METER_Y + 2, BUDGET_BAR_W, BUDGET_BAR_H, 0x333300).setOrigin(0, 0)
+    this._budgetBar   = this.add.rectangle(BUDGET_METER_X + 8, BUDGET_METER_Y + 2, BUDGET_BAR_W, BUDGET_BAR_H, 0xffe066).setOrigin(0, 0)
+
+    // SLA timer (INCIDENT only)
+    if (mode === BATTLE_MODES.INCIDENT) {
+      this._slaText = this.add.text(SLA_TIMER_X, SLA_TIMER_Y, this._slaLabel(), {
+        ...textStyle, color: '#ff6666',
+      })
+    }
+  }
+
+  _hpLabel() {
+    const { hp, maxHp } = this._battleState.player
+    return `${hp}/${maxHp}`
+  }
+
+  _slaLabel() {
+    const timer = this._battleState.slaTimer
+    return `SLA:${timer ?? '-'}`
+  }
+
+  // -------------------------------------------------------------------------
+  // Skill menu — navigable list of active skills
+  // -------------------------------------------------------------------------
+  _buildSkillMenu() {
+    this._skillMenuItems = []
+    const style = { fontFamily: CONFIG.FONT, fontSize: '6px', color: '#ffffff' }
+
+    for (let i = 0; i < this._activeSkills.length; i++) {
+      const skill = this._activeSkills[i]
+      const text  = this.add.text(
+        SKILL_MENU_X + 8,
+        SKILL_MENU_Y + i * SKILL_MENU_H,
+        skill.displayName ?? skill.id,
+        style,
+      )
+      this._skillMenuItems.push(text)
+    }
+
+    // Arrow cursor
+    this._menuArrow = this.add.text(SKILL_MENU_X, SKILL_MENU_Y, '>', {
+      fontFamily: CONFIG.FONT, fontSize: '6px', color: '#ffe066',
+    })
+
+    this._refreshMenuCursor()
+  }
+
+  _refreshMenuCursor() {
+    if (!this._menuArrow) return
+    this._menuArrow.setY(SKILL_MENU_Y + this._skillIndex * SKILL_MENU_H)
+  }
+
+  _refreshMenuHighlight() {
+    this._skillMenuItems.forEach((item, i) => {
+      item.setColor(i === this._skillIndex ? '#ffe066' : '#ffffff')
+    })
+  }
+
+  // -------------------------------------------------------------------------
+  // Log box — displays last event dialog
+  // -------------------------------------------------------------------------
+  _buildLogBox() {
+    this._logText = this.add.text(LOG_X, LOG_Y, '', {
+      fontFamily:  CONFIG.FONT,
+      fontSize:    '6px',
+      color:       '#f8f8f8',
+      wordWrap:    { width: CONFIG.WIDTH - 8 },
+    })
+  }
+
+  _showLog(text) {
+    if (this._logText) this._logText.setText(text)
+  }
+
+  // -------------------------------------------------------------------------
+  // Input — arrow keys to navigate, Z to confirm, X to cancel
+  // -------------------------------------------------------------------------
+  _setupInput() {
+    const keys = this.input.keyboard.addKeys({
+      up:      Phaser.Input.Keyboard.KeyCodes.UP,
+      down:    Phaser.Input.Keyboard.KeyCodes.DOWN,
+      confirm: Phaser.Input.Keyboard.KeyCodes.Z,
+      cancel:  Phaser.Input.Keyboard.KeyCodes.X,
+    })
+
+    this._keys = keys
+  }
+
+  update() {
+    if (this._animating) return
+
+    const keys = this._keys
+    if (!keys) return
+
+    if (Phaser.Input.Keyboard.JustDown(keys.up)) {
+      this._skillIndex = Math.max(0, this._skillIndex - 1)
+      this._refreshMenuCursor()
+      this._refreshMenuHighlight()
+    }
+    if (Phaser.Input.Keyboard.JustDown(keys.down)) {
+      this._skillIndex = Math.min(this._activeSkills.length - 1, this._skillIndex + 1)
+      this._refreshMenuCursor()
+      this._refreshMenuHighlight()
+    }
+    if (Phaser.Input.Keyboard.JustDown(keys.confirm)) {
+      this._useSkill(this._activeSkills[this._skillIndex])
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // _useSkill — delegate to engine, then animate events
+  // -------------------------------------------------------------------------
+  _useSkill(skill) {
+    if (!skill || this._animating) return
+
+    // Assess quality before the turn (opponent HP check after)
+    const quality = assessQuality(skill, this._battleState.opponent, this._battleState.domainRevealed)
+    this._battleState.winningTier = quality
+
+    const events = resolveTurn(this._battleState, skill)
+    this._animateEvents(events)
+  }
+
+  // -------------------------------------------------------------------------
+  // _animateEvents — render each BattleEvent in sequence
+  // The engine never renders; this function is the only place that touches
+  // Phaser objects as a result of engine output.
+  // -------------------------------------------------------------------------
+  _animateEvents(events) {
+    this._animating = true
+    let index = 0
+
+    const next = () => {
+      if (index >= events.length) {
+        this._animating = false
+        this._refreshHUD()
+        return
+      }
+
+      const event = events[index++]
+      this._renderEvent(event, next)
+    }
+
+    next()
+  }
+
+  _renderEvent(event, callback) {
+    switch (event.type) {
+      case 'skill_used':
+        this._showLog(`Used: ${event.skillId}`)
+        this.time.delayedCall(300, callback)
+        break
+
+      case 'damage':
+        if (event.target === 'opponent') {
+          this._showLog(`Dealt ${event.value} damage!`)
+        } else {
+          this._showLog(`Took ${event.value} damage!`)
+        }
+        this._refreshHUD()
+        this.time.delayedCall(400, callback)
+        break
+
+      case 'heal':
+        this._showLog(`Restored ${event.value} HP!`)
+        this._refreshHUD()
+        this.time.delayedCall(400, callback)
+        break
+
+      case 'domain_reveal':
+        this._showLog(`Domain revealed: ${event.value}!`)
+        this._enemyDomainText?.setText(`[${event.value}]`)
+        this.time.delayedCall(500, callback)
+        break
+
+      case 'sla_tick':
+        if (this._slaText) this._slaText.setText(this._slaLabel())
+        callback()
+        break
+
+      case 'sla_breach':
+        this._showLog('SLA BREACH! Penalty applied.')
+        if (this._slaText) this._slaText.setColor('#ff0000')
+        this.time.delayedCall(600, callback)
+        break
+
+      case 'status_tick':
+      case 'status_remove':
+        callback()
+        break
+
+      case 'reputation':
+        this._showLog(event.value < 0
+          ? `Reputation -${Math.abs(event.value)}. Shame +${event.shameDelta ?? 0}.`
+          : `Reputation +${event.value}.`)
+        this.time.delayedCall(400, callback)
+        break
+
+      case 'xp_gain':
+        this._showLog(`+${event.value} XP`)
+        this.time.delayedCall(500, callback)
+        break
+
+      case 'teach_skill':
+        this._showLog(`Learned: ${event.value}!`)
+        this.time.delayedCall(800, callback)
+        break
+
+      case 'battle_end':
+        this._onBattleEnd(event.value)
+        break
+
+      default:
+        callback()
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // _onBattleEnd — sync GameState then return to world
+  // -------------------------------------------------------------------------
+  _onBattleEnd(result) {
+    const { player } = this._battleState
+
+    // Write engine state back to GameState
+    GameState.player.hp         = player.hp
+    GameState.player.reputation = player.reputation
+    GameState.player.shamePoints = player.shamePoints
+    markDirty()
+
+    if (result === 'win') {
+      GameState.stats.battlesWon++
+    } else {
+      GameState.stats.battlesLost++
+    }
+
+    this._showLog(result === 'win' ? 'Victory!' : 'Defeated...')
+    this.time.delayedCall(1200, () => {
+      this.fadeToScene(this._returnScene ?? 'WorldScene')
+    })
+  }
+
+  // -------------------------------------------------------------------------
+  // _refreshHUD — redraw all HUD bars from current engine state
+  // -------------------------------------------------------------------------
+  _refreshHUD() {
+    const { player, opponent } = this._battleState
+    if (!player || !opponent) return
+
+    // Player HP bar
+    const playerRatio = Math.max(0, player.hp / player.maxHp)
+    this._playerHpBar?.setDisplaySize(HP_BAR_W * playerRatio, HP_BAR_H)
+    this._playerHpText?.setText(this._hpLabel())
+
+    // Player HP bar colour: green > 50%, yellow > 25%, red otherwise
+    const hpColour = playerRatio > 0.5 ? 0x00cc44 : playerRatio > 0.25 ? 0xffe066 : 0xff3300
+    this._playerHpBar?.setFillStyle(hpColour)
+
+    // Enemy HP bar
+    const enemyRatio = Math.max(0, opponent.hp / opponent.maxHp)
+    this._enemyHpBar?.setDisplaySize(HP_BAR_W * enemyRatio, HP_BAR_H)
+
+    // Budget bar
+    const maxBudget  = GameState.player.budget ?? 500
+    const budgetRatio = Math.min(1, player.budget / maxBudget)
+    this._budgetBar?.setDisplaySize(BUDGET_BAR_W * budgetRatio, BUDGET_BAR_H)
+
+    // SLA timer text
+    if (this._slaText) this._slaText.setText(this._slaLabel())
+  }
+}

--- a/tests/BattleEngine.test.js
+++ b/tests/BattleEngine.test.js
@@ -1,0 +1,519 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  createBattleState,
+  statusTickPhase,
+  skillPhase,
+  slaTickPhase,
+  enemyPhase,
+  turnEndPhase,
+  resolveTurn,
+  BATTLE_MODES,
+} from '../src/engine/BattleEngine.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makePlayer(overrides = {}) {
+  return {
+    hp:           100,
+    maxHp:        100,
+    budget:       500,
+    reputation:   50,
+    shamePoints:  0,
+    level:        1,
+    xp:           0,
+    activeSlots:  4,
+    ...overrides,
+  }
+}
+
+function makeOpponent(overrides = {}) {
+  return {
+    id:         'test_incident',
+    name:       'Test Incident',
+    domain:     'cloud',
+    hp:         60,
+    maxHp:      60,
+    difficulty: 2,
+    ...overrides,
+  }
+}
+
+function makeDamageSkill(overrides = {}) {
+  return {
+    id:       'az_webapp_deploy',
+    domain:   'cloud',
+    tier:     'standard',
+    isCursed: false,
+    effect:   { type: 'damage', value: 30 },
+    sideEffect: null,
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// createBattleState
+// ---------------------------------------------------------------------------
+
+describe('createBattleState', () => {
+  it('creates INCIDENT battle state with SLA timer', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer(), makeOpponent(), { slaTimer: 10 })
+    expect(state.mode).toBe(BATTLE_MODES.INCIDENT)
+    expect(state.slaTimer).toBe(10)
+    expect(state.domainRevealed).toBe(false)
+    expect(state.turn).toBe(1)
+    expect(state.log).toEqual([])
+  })
+
+  it('creates ENGINEER battle state with telegraphed move', () => {
+    const state = createBattleState(BATTLE_MODES.ENGINEER, makePlayer(), makeOpponent(), {
+      telegraphedMove: 'kubectl_drain',
+    })
+    expect(state.mode).toBe(BATTLE_MODES.ENGINEER)
+    expect(state.telegraphedMove).toBe('kubectl_drain')
+    expect(state.slaTimer).toBeNull()
+  })
+
+  it('opponent domain is hidden in INCIDENT mode', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer(), makeOpponent())
+    expect(state.domainRevealed).toBe(false)
+  })
+
+  it('opponent domain is visible in ENGINEER mode', () => {
+    const state = createBattleState(BATTLE_MODES.ENGINEER, makePlayer(), makeOpponent())
+    expect(state.domainRevealed).toBe(true)
+  })
+
+  it('initialises with empty player and opponent status arrays', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer(), makeOpponent())
+    expect(state.playerStatuses).toEqual([])
+    expect(state.opponentStatuses).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// statusTickPhase
+// ---------------------------------------------------------------------------
+
+describe('statusTickPhase', () => {
+  it('returns empty event array when no statuses are active', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer(), makeOpponent())
+    const events = statusTickPhase(state)
+    expect(events).toBeInstanceOf(Array)
+    expect(events).toHaveLength(0)
+  })
+
+  it('decrements status duration and emits status_tick event', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer(), makeOpponent())
+    state.playerStatuses = [{ name: 'throttled', duration: 3 }]
+    const events = statusTickPhase(state)
+    expect(state.playerStatuses[0].duration).toBe(2)
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: 'status_tick', target: 'player' })
+    )
+  })
+
+  it('removes expired status and emits status_remove event', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer(), makeOpponent())
+    state.playerStatuses = [{ name: 'cold_start', duration: 1 }]
+    const events = statusTickPhase(state)
+    expect(state.playerStatuses).toHaveLength(0)
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: 'status_remove', target: 'player' })
+    )
+  })
+
+  it('does not remove permanent statuses (duration -1)', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer(), makeOpponent())
+    state.playerStatuses = [{ name: 'technical_debt', duration: -1 }]
+    const events = statusTickPhase(state)
+    expect(state.playerStatuses).toHaveLength(1)
+    expect(state.playerStatuses[0].duration).toBe(-1)
+  })
+
+  it('ticks multiple statuses independently', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer(), makeOpponent())
+    state.playerStatuses = [
+      { name: 'throttled', duration: 3 },
+      { name: 'cold_start', duration: 1 },
+      { name: 'technical_debt', duration: -1 },
+    ]
+    statusTickPhase(state)
+    expect(state.playerStatuses).toHaveLength(2) // cold_start expired
+    expect(state.playerStatuses.find(s => s.name === 'throttled').duration).toBe(2)
+    expect(state.playerStatuses.find(s => s.name === 'technical_debt').duration).toBe(-1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// skillPhase
+// ---------------------------------------------------------------------------
+
+describe('skillPhase', () => {
+  it('emits skill_used event', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer(), makeOpponent())
+    const skill = makeDamageSkill()
+    const events = skillPhase(state, skill)
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: 'skill_used' })
+    )
+  })
+
+  it('emits damage event for damage skills', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer(), makeOpponent())
+    const skill = makeDamageSkill({ domain: 'cloud' }) // cloud vs cloud = neutral
+    const events = skillPhase(state, skill)
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: 'damage', target: 'opponent', value: 30 })
+    )
+  })
+
+  it('applies domain multiplier to damage', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer(), makeOpponent({ domain: 'iac' }))
+    const skill = makeDamageSkill({ domain: 'cloud' }) // cloud is strong against iac
+    const events = skillPhase(state, skill)
+    const dmgEvent = events.find(e => e.type === 'damage')
+    expect(dmgEvent.value).toBe(60) // 30 * 2.0
+  })
+
+  it('reduces opponent HP by damage value', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer(), makeOpponent({ hp: 60 }))
+    const skill = makeDamageSkill({ domain: 'cloud', effect: { type: 'damage', value: 25 } })
+    skillPhase(state, skill)
+    expect(state.opponent.hp).toBe(35)
+  })
+
+  it('opponent HP does not go below 0', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer(), makeOpponent({ hp: 10 }))
+    const skill = makeDamageSkill({ domain: 'cloud', effect: { type: 'damage', value: 100 } })
+    skillPhase(state, skill)
+    expect(state.opponent.hp).toBe(0)
+  })
+
+  it('emits domain_reveal event for reveal_domain effect', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer(), makeOpponent())
+    const skill = {
+      id: 'grep_logs', domain: 'linux', tier: 'standard',
+      isCursed: false, effect: { type: 'reveal_domain', value: 1 }, sideEffect: null,
+    }
+    const events = skillPhase(state, skill)
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: 'domain_reveal' })
+    )
+    expect(state.domainRevealed).toBe(true)
+  })
+
+  it('emits reputation event for cursed skill', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer(), makeOpponent())
+    const skill = {
+      id: 'force_push', domain: null, tier: 'cursed', isCursed: true,
+      effect: { type: 'damage', value: 30 },
+      sideEffect: { shame: 1, reputation: -8, description: "Deletes teammate work." },
+    }
+    const events = skillPhase(state, skill)
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: 'reputation' })
+    )
+  })
+
+  it('does not emit damage event for heal skill', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer({ hp: 80 }), makeOpponent())
+    const skill = { id: 'systemctl_restart', domain: 'linux', tier: 'standard', isCursed: false,
+      effect: { type: 'heal', value: 20 }, sideEffect: null }
+    const events = skillPhase(state, skill)
+    const dmgEvent = events.find(e => e.type === 'damage')
+    expect(dmgEvent).toBeUndefined()
+  })
+
+  it('emits heal event for heal skill', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer({ hp: 80 }), makeOpponent())
+    const skill = { id: 'systemctl_restart', domain: 'linux', tier: 'standard', isCursed: false,
+      effect: { type: 'heal', value: 20 }, sideEffect: null }
+    const events = skillPhase(state, skill)
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: 'heal', target: 'player' })
+    )
+  })
+
+  it('player HP does not exceed maxHp when healed', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer({ hp: 95, maxHp: 100 }), makeOpponent())
+    const skill = { id: 'systemctl_restart', domain: 'linux', tier: 'standard', isCursed: false,
+      effect: { type: 'heal', value: 20 }, sideEffect: null }
+    skillPhase(state, skill)
+    expect(state.player.hp).toBe(100)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// slaTickPhase
+// ---------------------------------------------------------------------------
+
+describe('slaTickPhase', () => {
+  it('decrements SLA timer by 1 each call', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer(), makeOpponent(), { slaTimer: 5 })
+    slaTickPhase(state)
+    expect(state.slaTimer).toBe(4)
+  })
+
+  it('emits sla_tick event each turn', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer(), makeOpponent(), { slaTimer: 5 })
+    const events = slaTickPhase(state)
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: 'sla_tick', value: 4 })
+    )
+  })
+
+  it('emits sla_breach event when timer hits 0', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer(), makeOpponent(), { slaTimer: 1 })
+    const events = slaTickPhase(state)
+    expect(state.slaTimer).toBe(0)
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: 'sla_breach' })
+    )
+  })
+
+  it('sla_breach applies HP penalty to player', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer({ hp: 100 }), makeOpponent(), { slaTimer: 1 })
+    slaTickPhase(state)
+    expect(state.player.hp).toBeLessThan(100)
+  })
+
+  it('sla_breach applies reputation penalty to player', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer({ reputation: 50 }), makeOpponent(), { slaTimer: 1 })
+    slaTickPhase(state)
+    expect(state.player.reputation).toBeLessThan(50)
+  })
+
+  it('returns empty array if SLA timer is null (ENGINEER mode)', () => {
+    const state = createBattleState(BATTLE_MODES.ENGINEER, makePlayer(), makeOpponent())
+    expect(state.slaTimer).toBeNull()
+    const events = slaTickPhase(state)
+    expect(events).toEqual([])
+  })
+
+  it('does not decrement below 0', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer(), makeOpponent(), { slaTimer: 0 })
+    slaTickPhase(state)
+    expect(state.slaTimer).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// enemyPhase
+// ---------------------------------------------------------------------------
+
+describe('enemyPhase', () => {
+  it('returns empty events in INCIDENT mode (no enemy turn)', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer(), makeOpponent())
+    const events = enemyPhase(state)
+    expect(events).toBeInstanceOf(Array)
+    expect(events).toHaveLength(0)
+  })
+
+  it('emits damage event for enemy attack in ENGINEER mode', () => {
+    const state = createBattleState(BATTLE_MODES.ENGINEER, makePlayer(), makeOpponent())
+    const events = enemyPhase(state)
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: 'damage', target: 'player' })
+    )
+  })
+
+  it('reduces player HP in ENGINEER mode', () => {
+    const state = createBattleState(BATTLE_MODES.ENGINEER, makePlayer({ hp: 100 }), makeOpponent())
+    enemyPhase(state)
+    expect(state.player.hp).toBeLessThan(100)
+  })
+
+  it('player HP does not go below 0 from enemy attack', () => {
+    const state = createBattleState(BATTLE_MODES.ENGINEER, makePlayer({ hp: 1 }), makeOpponent())
+    enemyPhase(state)
+    expect(state.player.hp).toBe(0)
+  })
+
+  it('emits skill_used event showing enemy move in ENGINEER mode', () => {
+    const state = createBattleState(BATTLE_MODES.ENGINEER, makePlayer(), makeOpponent(), {
+      telegraphedMove: 'kubectl_drain',
+    })
+    const events = enemyPhase(state)
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: 'skill_used' })
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// turnEndPhase
+// ---------------------------------------------------------------------------
+
+describe('turnEndPhase', () => {
+  it('emits battle_end win event when opponent HP is 0', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer(), makeOpponent({ hp: 0 }))
+    const events = turnEndPhase(state)
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: 'battle_end', value: 'win' })
+    )
+  })
+
+  it('emits battle_end lose event when player HP is 0', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer({ hp: 0 }), makeOpponent())
+    const events = turnEndPhase(state)
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: 'battle_end', value: 'lose' })
+    )
+  })
+
+  it('emits battle_end lose when SLA breached AND incident not resolved', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer(), makeOpponent({ hp: 30 }), { slaTimer: 0 })
+    state.slaBreach = true
+    const events = turnEndPhase(state)
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: 'battle_end', value: 'lose' })
+    )
+  })
+
+  it('emits win (with penalties) when SLA breached BUT incident resolved (hp = 0)', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer(), makeOpponent({ hp: 0 }), { slaTimer: 0 })
+    state.slaBreach = true
+    const events = turnEndPhase(state)
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: 'battle_end', value: 'win' })
+    )
+  })
+
+  it('increments turn counter when battle is not over', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer(), makeOpponent({ hp: 50 }))
+    const before = state.turn
+    turnEndPhase(state)
+    expect(state.turn).toBe(before + 1)
+  })
+
+  it('emits xp_gain event on win', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer(), makeOpponent({ hp: 0, difficulty: 3 }))
+    state.winningTier = 'standard'
+    const events = turnEndPhase(state)
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: 'xp_gain' })
+    )
+  })
+
+  it('emits teach_skill event on ENGINEER win if opponent has a teach skill', () => {
+    const state = createBattleState(BATTLE_MODES.ENGINEER, makePlayer(),
+      makeOpponent({ hp: 0, teachSkillId: 'helm_upgrade' }))
+    state.winningTier = 'standard'
+    const events = turnEndPhase(state)
+    expect(events).toContainEqual(
+      expect.objectContaining({ type: 'teach_skill', value: 'helm_upgrade' })
+    )
+  })
+
+  it('returns empty event array when battle is still ongoing', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer({ hp: 80 }), makeOpponent({ hp: 40 }))
+    const events = turnEndPhase(state)
+    expect(events.find(e => e.type === 'battle_end')).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// resolveTurn — full phase ordering
+// ---------------------------------------------------------------------------
+
+describe('resolveTurn — phase ordering', () => {
+  it('returns a flat array of all phase events in order', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer(), makeOpponent({ hp: 60 }), { slaTimer: 5 })
+    const skill = makeDamageSkill()
+    const events = resolveTurn(state, skill)
+    expect(events).toBeInstanceOf(Array)
+    expect(events.length).toBeGreaterThan(0)
+  })
+
+  it('always emits sla_tick before any battle_end in INCIDENT mode', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer(), makeOpponent({ hp: 60 }), { slaTimer: 3 })
+    const skill = makeDamageSkill()
+    const events = resolveTurn(state, skill)
+    const slaIdx = events.findIndex(e => e.type === 'sla_tick')
+    const endIdx = events.findIndex(e => e.type === 'battle_end')
+    if (slaIdx !== -1 && endIdx !== -1) {
+      expect(slaIdx).toBeLessThan(endIdx)
+    }
+  })
+
+  it('every event has a type string', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer(), makeOpponent(), { slaTimer: 5 })
+    const skill = makeDamageSkill()
+    const events = resolveTurn(state, skill)
+    for (const event of events) {
+      expect(typeof event.type).toBe('string')
+    }
+  })
+
+  it('every damage event has a numeric value', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer(), makeOpponent(), { slaTimer: 5 })
+    const skill = makeDamageSkill()
+    const events = resolveTurn(state, skill)
+    for (const event of events.filter(e => e.type === 'damage')) {
+      expect(typeof event.value).toBe('number')
+    }
+  })
+
+  it('emits skill_used before damage in same turn', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer(), makeOpponent(), { slaTimer: 5 })
+    const skill = makeDamageSkill()
+    const events = resolveTurn(state, skill)
+    const usedIdx = events.findIndex(e => e.type === 'skill_used')
+    const dmgIdx  = events.findIndex(e => e.type === 'damage')
+    if (usedIdx !== -1 && dmgIdx !== -1) {
+      expect(usedIdx).toBeLessThan(dmgIdx)
+    }
+  })
+
+  it('win before breach: resolving incident before SLA expires gives speed bonus xp', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer(),
+      makeOpponent({ hp: 10, difficulty: 2 }), { slaTimer: 8 })
+    state.winningTier = 'optimal'
+    const skill = makeDamageSkill({ effect: { type: 'damage', value: 100 } })
+    const events = resolveTurn(state, skill)
+    const xpEvent = events.find(e => e.type === 'xp_gain')
+    // No breach, optimal tier → full XP
+    expect(xpEvent).toBeDefined()
+    expect(xpEvent.value).toBeGreaterThan(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// BattleEvent shape validation
+// ---------------------------------------------------------------------------
+
+describe('BattleEvent shape', () => {
+  const VALID_TYPES = [
+    'skill_used', 'damage', 'heal', 'domain_reveal',
+    'sla_tick', 'sla_breach', 'status_tick', 'status_remove',
+    'status_apply', 'reputation', 'xp_gain', 'teach_skill', 'battle_end',
+  ]
+
+  it('all emitted events have recognised type strings', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer(), makeOpponent(), { slaTimer: 5 })
+    const skill = makeDamageSkill()
+    const events = resolveTurn(state, skill)
+    for (const event of events) {
+      expect(VALID_TYPES).toContain(event.type)
+    }
+  })
+
+  it('damage events always have a non-negative value', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer(), makeOpponent(), { slaTimer: 5 })
+    const skill = makeDamageSkill()
+    const events = resolveTurn(state, skill)
+    for (const event of events.filter(e => e.type === 'damage')) {
+      expect(event.value).toBeGreaterThanOrEqual(0)
+    }
+  })
+
+  it('events are never undefined', () => {
+    const state = createBattleState(BATTLE_MODES.INCIDENT, makePlayer(), makeOpponent(), { slaTimer: 5 })
+    const skill = makeDamageSkill()
+    const events = resolveTurn(state, skill)
+    expect(events).not.toContain(undefined)
+    expect(events).not.toContain(null)
+  })
+})

--- a/tests/SkillEngine.test.js
+++ b/tests/SkillEngine.test.js
@@ -1,0 +1,279 @@
+import { describe, it, expect } from 'vitest'
+import {
+  calculateDamage,
+  calculateXP,
+  assessQuality,
+  getDomainMultiplier,
+  applyShameAndReputation,
+} from '../src/engine/SkillEngine.js'
+
+// ---------------------------------------------------------------------------
+// getDomainMultiplier
+// ---------------------------------------------------------------------------
+
+describe('getDomainMultiplier', () => {
+  it('returns 2.0 when skill domain is strong against opponent domain', () => {
+    // linux is strong against security
+    expect(getDomainMultiplier('linux', 'security')).toBe(2.0)
+    // kubernetes is strong against linux
+    expect(getDomainMultiplier('kubernetes', 'linux')).toBe(2.0)
+    // cloud is strong against iac
+    expect(getDomainMultiplier('cloud', 'iac')).toBe(2.0)
+  })
+
+  it('returns 0.5 when skill domain is weak against opponent domain', () => {
+    // linux is weak against kubernetes
+    expect(getDomainMultiplier('linux', 'kubernetes')).toBe(0.5)
+    // security is weak against linux
+    expect(getDomainMultiplier('security', 'linux')).toBe(0.5)
+    // containers is weak against iac
+    expect(getDomainMultiplier('containers', 'iac')).toBe(0.5)
+  })
+
+  it('returns 1.0 for neutral matchups (neither strong nor weak)', () => {
+    // linux vs cloud — no relationship
+    expect(getDomainMultiplier('linux', 'cloud')).toBe(1.0)
+    // kubernetes vs security — no relationship
+    expect(getDomainMultiplier('kubernetes', 'security')).toBe(1.0)
+    // iac vs serverless — no relationship
+    expect(getDomainMultiplier('iac', 'serverless')).toBe(1.0)
+  })
+
+  it('returns 0 when skill domain is observability (support domain — no damage)', () => {
+    expect(getDomainMultiplier('observability', 'linux')).toBe(0)
+    expect(getDomainMultiplier('observability', 'cloud')).toBe(0)
+    expect(getDomainMultiplier('observability', 'kubernetes')).toBe(0)
+  })
+
+  it('returns 1.0 when skill domain is null (cursed/nuclear bypass — flat damage)', () => {
+    expect(getDomainMultiplier(null, 'linux')).toBe(1.0)
+    expect(getDomainMultiplier(null, 'kubernetes')).toBe(1.0)
+    expect(getDomainMultiplier(null, 'security')).toBe(1.0)
+  })
+
+  it('returns 1.0 when opponent domain is null (unknown domain)', () => {
+    expect(getDomainMultiplier('linux', null)).toBe(1.0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// calculateDamage
+// ---------------------------------------------------------------------------
+
+describe('calculateDamage', () => {
+  it('applies strong multiplier (2.0×) for advantageous matchup', () => {
+    // linux is strong against security
+    const skill = { domain: 'linux', tier: 'standard', effect: { type: 'damage', value: 30 } }
+    expect(calculateDamage(skill, 'security')).toBe(60)
+  })
+
+  it('applies weak multiplier (0.5×) for disadvantageous matchup', () => {
+    // linux is weak against kubernetes
+    const skill = { domain: 'linux', tier: 'standard', effect: { type: 'damage', value: 30 } }
+    expect(calculateDamage(skill, 'kubernetes')).toBe(15)
+  })
+
+  it('applies neutral multiplier (1.0×) for unrelated domains', () => {
+    const skill = { domain: 'linux', tier: 'standard', effect: { type: 'damage', value: 30 } }
+    expect(calculateDamage(skill, 'cloud')).toBe(30)
+  })
+
+  it('returns 0 for observability skills (support domain)', () => {
+    const skill = { domain: 'observability', tier: 'standard', effect: { type: 'reveal_domain', value: 1 } }
+    expect(calculateDamage(skill, 'linux')).toBe(0)
+  })
+
+  it('deals flat neutral damage for cursed skill (domain null bypasses matchups)', () => {
+    const skill = { domain: null, tier: 'cursed', isCursed: true, effect: { type: 'damage', value: 40 } }
+    expect(calculateDamage(skill, 'linux')).toBe(40)
+    expect(calculateDamage(skill, 'kubernetes')).toBe(40)
+  })
+
+  it('deals flat neutral damage for nuclear skill (domain null bypasses matchups)', () => {
+    const skill = { domain: null, tier: 'nuclear', isCursed: true, effect: { type: 'damage', value: 50 } }
+    expect(calculateDamage(skill, 'security')).toBe(50)
+    expect(calculateDamage(skill, 'iac')).toBe(50)
+  })
+
+  it('floors the result (no fractional damage)', () => {
+    // 0.5 * 25 = 12.5 → should floor to 12
+    const skill = { domain: 'linux', tier: 'standard', effect: { type: 'damage', value: 25 } }
+    expect(calculateDamage(skill, 'kubernetes')).toBe(12)
+  })
+
+  it('returns 0 for skills without a damage effect', () => {
+    const healSkill = { domain: 'linux', tier: 'standard', effect: { type: 'heal', value: 20 } }
+    expect(calculateDamage(healSkill, 'security')).toBe(0)
+  })
+
+  it('returns 0 for skill with damage value 0', () => {
+    const skill = { domain: 'cloud', tier: 'standard', effect: { type: 'damage', value: 0 } }
+    expect(calculateDamage(skill, 'iac')).toBe(0)
+  })
+
+  it('handles all 7 combat domains in a full cycle: linux→security→serverless→cloud→iac→containers→kubernetes→linux', () => {
+    const cycle = ['linux', 'security', 'serverless', 'cloud', 'iac', 'containers', 'kubernetes']
+    for (let i = 0; i < cycle.length; i++) {
+      const attacker = cycle[i]
+      const defender = cycle[(i + 1) % cycle.length]
+      const skill = { domain: attacker, tier: 'standard', effect: { type: 'damage', value: 10 } }
+      expect(calculateDamage(skill, defender)).toBe(20) // strong matchup
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// calculateXP
+// ---------------------------------------------------------------------------
+
+describe('calculateXP', () => {
+  // Formula: Math.floor(difficulty * 30 * MULTIPLIERS[tier])
+  // Multipliers: optimal=2, standard=1, shortcut=0.5, cursed=0.25, nuclear=0
+
+  it('calculates optimal XP at 2× multiplier', () => {
+    expect(calculateXP(5, 'optimal')).toBe(Math.floor(5 * 30 * 2))   // 300
+    expect(calculateXP(1, 'optimal')).toBe(Math.floor(1 * 30 * 2))   // 60
+    expect(calculateXP(10, 'optimal')).toBe(Math.floor(10 * 30 * 2)) // 600
+  })
+
+  it('calculates standard XP at 1× multiplier', () => {
+    expect(calculateXP(5, 'standard')).toBe(Math.floor(5 * 30 * 1))  // 150
+    expect(calculateXP(3, 'standard')).toBe(Math.floor(3 * 30 * 1))  // 90
+  })
+
+  it('calculates shortcut XP at 0.5× multiplier', () => {
+    expect(calculateXP(5, 'shortcut')).toBe(Math.floor(5 * 30 * 0.5)) // 75
+    expect(calculateXP(3, 'shortcut')).toBe(Math.floor(3 * 30 * 0.5)) // 45
+  })
+
+  it('calculates cursed XP at 0.25× multiplier', () => {
+    expect(calculateXP(5, 'cursed')).toBe(Math.floor(5 * 30 * 0.25)) // 37
+    expect(calculateXP(4, 'cursed')).toBe(Math.floor(4 * 30 * 0.25)) // 30
+  })
+
+  it('calculates nuclear XP at 0× multiplier (always 0)', () => {
+    expect(calculateXP(5, 'nuclear')).toBe(0)
+    expect(calculateXP(100, 'nuclear')).toBe(0)
+  })
+
+  it('returns 0 for unknown tier', () => {
+    expect(calculateXP(5, 'unknown_tier')).toBe(0)
+  })
+
+  it('floors fractional results', () => {
+    // 7 * 30 * 0.25 = 52.5 → 52
+    expect(calculateXP(7, 'cursed')).toBe(52)
+  })
+
+  it('scales linearly with opponent difficulty', () => {
+    const xp1 = calculateXP(2, 'standard')
+    const xp2 = calculateXP(4, 'standard')
+    expect(xp2).toBe(xp1 * 2)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// assessQuality
+// ---------------------------------------------------------------------------
+
+describe('assessQuality', () => {
+  it('returns optimal when correct domain used AND domain was revealed first', () => {
+    const skill = { domain: 'cloud', tier: 'standard' }
+    const opponent = { domain: 'iac' }  // cloud is strong against iac
+    expect(assessQuality(skill, opponent, true)).toBe('optimal')
+  })
+
+  it('returns standard when correct domain used but domain was NOT revealed', () => {
+    const skill = { domain: 'cloud', tier: 'standard' }
+    const opponent = { domain: 'iac' }
+    expect(assessQuality(skill, opponent, false)).toBe('standard')
+  })
+
+  it('returns shortcut when wrong domain but incident still resolved (opponent hp <= 0)', () => {
+    const skill = { domain: 'linux', tier: 'standard' }
+    const opponent = { domain: 'cloud', hp: 0 }  // resolved, but wrong domain
+    expect(assessQuality(skill, opponent, false)).toBe('shortcut')
+  })
+
+  it('returns cursed when skill tier is cursed', () => {
+    const skill = { domain: null, tier: 'cursed', isCursed: true }
+    const opponent = { domain: 'cloud', hp: 0 }
+    expect(assessQuality(skill, opponent, true)).toBe('cursed')
+  })
+
+  it('returns nuclear when skill tier is nuclear', () => {
+    const skill = { domain: null, tier: 'nuclear', isCursed: true }
+    const opponent = { domain: 'cloud', hp: 0 }
+    expect(assessQuality(skill, opponent, true)).toBe('nuclear')
+  })
+
+  it('cursed tier takes precedence over correct domain', () => {
+    const skill = { domain: 'cloud', tier: 'cursed', isCursed: true }
+    const opponent = { domain: 'iac' }
+    expect(assessQuality(skill, opponent, true)).toBe('cursed')
+  })
+
+  it('nuclear tier takes precedence over correct domain', () => {
+    const skill = { domain: 'cloud', tier: 'nuclear', isCursed: true }
+    const opponent = { domain: 'iac' }
+    expect(assessQuality(skill, opponent, true)).toBe('nuclear')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// applyShameAndReputation
+// ---------------------------------------------------------------------------
+
+describe('applyShameAndReputation', () => {
+  it('cursed skill adds 1 shame and reduces reputation', () => {
+    const player = { shamePoints: 0, reputation: 50 }
+    const skill = { tier: 'cursed', isCursed: true, sideEffect: { shame: 1, reputation: -8 } }
+    const result = applyShameAndReputation(player, skill)
+    expect(result.shamePoints).toBe(1)
+    expect(result.reputation).toBe(42)
+  })
+
+  it('nuclear skill adds 2 shame and reduces reputation more', () => {
+    const player = { shamePoints: 0, reputation: 50 }
+    const skill = { tier: 'nuclear', isCursed: true, sideEffect: { shame: 2, reputation: -15 } }
+    const result = applyShameAndReputation(player, skill)
+    expect(result.shamePoints).toBe(2)
+    expect(result.reputation).toBe(35)
+  })
+
+  it('optimal skill does not add shame and increases reputation', () => {
+    const player = { shamePoints: 0, reputation: 50 }
+    const skill = { tier: 'optimal', isCursed: false, sideEffect: null }
+    const result = applyShameAndReputation(player, skill)
+    expect(result.shamePoints).toBe(0)
+    expect(result.reputation).toBeGreaterThanOrEqual(50)
+  })
+
+  it('standard skill does not add shame and increases reputation', () => {
+    const player = { shamePoints: 2, reputation: 40 }
+    const skill = { tier: 'standard', isCursed: false, sideEffect: null }
+    const result = applyShameAndReputation(player, skill)
+    expect(result.shamePoints).toBe(2) // shame never decrements
+    expect(result.reputation).toBeGreaterThanOrEqual(40)
+  })
+
+  it('reputation is clamped between 0 and 100', () => {
+    const playerLow = { shamePoints: 0, reputation: 5 }
+    const skill = { tier: 'nuclear', isCursed: true, sideEffect: { shame: 2, reputation: -20 } }
+    const result = applyShameAndReputation(playerLow, skill)
+    expect(result.reputation).toBeGreaterThanOrEqual(0)
+
+    const playerHigh = { shamePoints: 0, reputation: 95 }
+    const optimalSkill = { tier: 'optimal', isCursed: false, sideEffect: null }
+    const result2 = applyShameAndReputation(playerHigh, optimalSkill)
+    expect(result2.reputation).toBeLessThanOrEqual(100)
+  })
+
+  it('does not mutate the original player object', () => {
+    const player = { shamePoints: 0, reputation: 50 }
+    const skill = { tier: 'cursed', isCursed: true, sideEffect: { shame: 1, reputation: -8 } }
+    applyShameAndReputation(player, skill)
+    expect(player.shamePoints).toBe(0)
+    expect(player.reputation).toBe(50)
+  })
+})


### PR DESCRIPTION
Implements issue #6 — the core combat system.

## Summary

### Engine (zero Phaser, fully unit-tested)
- **BattleEngine**: phase-based turn queue — `StatusTickPhase → SkillPhase → SlaTickPhase → EnemyPhase → TurnEndPhase`. Two modes: `INCIDENT` (hidden domain, SLA timer) and `ENGINEER` (telegraphed moves, teach-on-win). Exports `createBattleState`, `resolveTurn`, and each phase individually for isolated testing
- **SkillEngine**: `calculateDamage` (domain matchups: ×2 strong, ×0.5 weak, ×1 neutral; cursed/nuclear bypass matchups), `calculateXP` (difficulty × 30 × tier multiplier), `assessQuality`, `applyShameAndReputation` (reputation clamped 0–100, shame never decrements)

### Scene (Phaser rendering only)
- **BattleScene**: HUD with HP bars, budget meter, SLA timer (INCIDENT mode). Navigable skill menu (↑↓ + Z). Animates `BattleEvent[]` arrays from the engine in sequence. Zero damage math — all logic delegated to engines

### Tests (written first — TDD)
- **SkillEngine**: 37 tests — domain multipliers, XP formula all 5 tiers, cursed bypass, shame/rep clamping
- **BattleEngine**: 49 tests — phase ordering, win/lose conditions, SLA breach, event shapes, INCIDENT vs ENGINEER mode differences

86 new tests, all passing.

## Test plan
- [ ] `npm test` — all engine tests pass
- [ ] Domain strong/weak multipliers apply correctly in damage calc
- [ ] Nuclear skill deals 0 XP, adds 2 shame
- [ ] SLA breach fires `sla_breach` event and penalises HP + rep
- [ ] ENGINEER mode: enemy telegraphs next move; teaches skill on win

https://claude.ai/code/session_01RweSkEaRsCT3pSMCtg3TCJ