### PR TITLE
feat: EncounterEngine, StatusEngine, seeded RNG (#9)

### DIFF
--- a/src/engine/EncounterEngine.js
+++ b/src/engine/EncounterEngine.js
@@ -1,0 +1,102 @@
+// EncounterEngine.js — Pool-based random encounter selection.
+// Pure logic only — no Phaser imports. Fully unit-testable with plain Node.js.
+
+import { ENCOUNTER_POOLS, getById as getEncounterById } from '#data/encounters.js'
+import { seedRandom, randInt } from '#utils/random.js'
+
+// Base pool weights
+const BASE_COMMON_WEIGHT  = 70
+const BASE_RARE_WEIGHT    = 25
+const BASE_CURSED_WEIGHT  = 5
+
+// Select an encounter from the pool for the given regionId.
+// Uses seeded RNG — never Math.random() — so same args always return same result.
+//
+// Returns { encounterType, enemyId, domain } or null when:
+//  - the regionId does not exist in ENCOUNTER_POOLS
+//  - all pools for the region are empty
+export function selectFromPool(regionId, seed, stepCount) {
+  const pool = ENCOUNTER_POOLS[regionId]
+  if (!pool) return null
+
+  const { common, rare, cursed } = pool
+
+  const allEmpty = common.length === 0 && rare.length === 0 && cursed.length === 0
+  if (allEmpty) return null
+
+  const rand = seedRandom(seed ^ (stepCount * 0x9e3779b9))
+
+  // Compute effective weights based on non-empty pools
+  const hasCursed = cursed.length > 0
+  const hasRare   = rare.length   > 0
+  const hasCommon = common.length > 0
+
+  let commonWeight = hasCommon ? BASE_COMMON_WEIGHT  : 0
+  let rareWeight   = hasRare   ? BASE_RARE_WEIGHT    : 0
+  let cursedWeight = hasCursed ? BASE_CURSED_WEIGHT  : 0
+
+  // Redistribute weight from empty pools proportionally
+  // If cursed pool is empty: split its weight proportionally to common and rare
+  if (!hasCursed) {
+    const totalRemaining = commonWeight + rareWeight
+    if (totalRemaining > 0) {
+      // redistribute BASE_CURSED_WEIGHT proportionally
+      commonWeight += hasCommon ? Math.round(BASE_CURSED_WEIGHT * (BASE_COMMON_WEIGHT / (BASE_COMMON_WEIGHT + BASE_RARE_WEIGHT))) : 0
+      rareWeight   += hasRare   ? Math.round(BASE_CURSED_WEIGHT * (BASE_RARE_WEIGHT   / (BASE_COMMON_WEIGHT + BASE_RARE_WEIGHT))) : 0
+    }
+    cursedWeight = 0
+  }
+
+  // If rare pool is also empty: all weight goes to common
+  if (!hasRare) {
+    commonWeight += rareWeight
+    rareWeight    = 0
+  }
+
+  if (!hasCommon) {
+    rareWeight += commonWeight
+    commonWeight = 0
+  }
+
+  const totalWeight = commonWeight + rareWeight + cursedWeight
+  const roll        = rand() * totalWeight
+
+  let selectedPool
+  if (roll < commonWeight) {
+    selectedPool = common
+  } else if (roll < commonWeight + rareWeight) {
+    selectedPool = rare
+  } else {
+    selectedPool = cursed
+  }
+
+  if (selectedPool.length === 0) return null
+
+  const idx     = randInt(rand, 0, selectedPool.length)
+  const enemyId = selectedPool[idx]
+
+  const encounter = getEncounterById(enemyId)
+  if (!encounter) return null
+
+  return {
+    encounterType: encounter.type,
+    enemyId:       encounter.id,
+    domain:        encounter.domain,
+  }
+}
+
+// Returns the probability (0–1) of triggering an encounter on the current step.
+// Starts low, increases with stepCount, caps at a maximum.
+// Pure function — same inputs always return same value.
+// Returns 0 on step 0 (no encounter immediately on entering a region).
+export function encounterChance(stepCount, seed) {
+  if (stepCount === 0) return 0
+
+  // Simple ramp: base 5% + 1% per step, cap at 25%
+  const BASE_CHANCE   = 0.05
+  const STEP_INCREASE = 0.01
+  const MAX_CHANCE    = 0.25
+
+  const rawChance = BASE_CHANCE + STEP_INCREASE * (stepCount - 1)
+  return Math.min(rawChance, MAX_CHANCE)
+}

--- a/src/engine/StatusEngine.js
+++ b/src/engine/StatusEngine.js
@@ -1,0 +1,94 @@
+// StatusEngine.js — Status effect application and decay per turn.
+// Pure logic only — no Phaser imports. Fully unit-testable with plain Node.js.
+
+import { STATUSES } from '../config.js'
+
+// Returns true if the given statusId is currently active on the target.
+// A status with remaining === -1 is permanent and always active.
+// A status with remaining <= 0 is not active.
+export function isStatusActive(battleState, target, statusId) {
+  const entry = battleState[target].statuses.find(s => s.id === statusId)
+  if (!entry) return false
+  return entry.remaining === -1 || entry.remaining > 0
+}
+
+// Apply a status effect to target.
+// Returns BattleEvent[].
+// - For technical_debt: always stacks (adds a new entry).
+// - For all other statuses: refreshes duration if already present.
+// - Unknown statusId: no-op, returns [].
+export function applyStatus(battleState, target, statusId) {
+  const definition = STATUSES[statusId]
+  if (!definition) return []
+
+  const { duration } = definition
+  const remaining = _resolveInitialDuration(duration)
+
+  const statuses = battleState[target].statuses
+
+  if (statusId === 'technical_debt') {
+    // technical_debt stacks — always push a new entry
+    statuses.push({ id: statusId, remaining })
+  } else {
+    // Refresh (or add) single entry
+    const existing = statuses.find(s => s.id === statusId)
+    if (existing) {
+      existing.remaining = remaining
+    } else {
+      statuses.push({ id: statusId, remaining })
+    }
+  }
+
+  return [
+    {
+      type:   'status_apply',
+      target,
+      value:  statusId,
+      text:   `${target} is now ${statusId}`,
+    },
+  ]
+}
+
+// Tick all statuses on target by one turn.
+// - Decrements remaining for finite statuses.
+// - Removes entries when remaining reaches 0 and emits status_expired.
+// - Never modifies permanent (remaining === -1) entries.
+// Returns BattleEvent[].
+export function tickStatuses(battleState, target) {
+  const events   = []
+  const statuses = battleState[target].statuses
+  const expired  = []
+
+  for (const entry of statuses) {
+    if (entry.remaining === -1) {
+      // Permanent — skip
+      continue
+    }
+
+    entry.remaining -= 1
+    events.push({ type: 'status_tick', target, value: entry.id, text: `${entry.id} ticked` })
+
+    if (entry.remaining <= 0) {
+      expired.push(entry.id)
+    }
+  }
+
+  // Remove expired entries and emit events
+  for (const statusId of expired) {
+    const idx = battleState[target].statuses.findIndex(s => s.id === statusId && s.remaining <= 0)
+    if (idx !== -1) battleState[target].statuses.splice(idx, 1)
+    events.push({ type: 'status_expired', target, value: statusId, text: `${statusId} expired` })
+  }
+
+  return events
+}
+
+// --- internal helpers ---
+
+function _resolveInitialDuration(duration) {
+  if (duration === 'random') {
+    // in_review: 1–3 turns
+    return Math.floor(Math.random() * 3) + 1
+  }
+  return duration
+}

--- a/src/engine/StatusEngine.js
+++ b/src/engine/StatusEngine.js
@@ -17,12 +17,14 @@ export function isStatusActive(battleState, target, statusId) {
 // - For technical_debt: always stacks (adds a new entry).
 // - For all other statuses: refreshes duration if already present.
 // - Unknown statusId: no-op, returns [].
-export function applyStatus(battleState, target, statusId) {
+// - randomFn: optional seeded random function (defaults to Math.random).
+//   Pass a seeded function (e.g. from utils/random.js) for reproducible replays.
+export function applyStatus(battleState, target, statusId, randomFn = Math.random) {
   const definition = STATUSES[statusId]
   if (!definition) return []
 
   const { duration } = definition
-  const remaining = _resolveInitialDuration(duration)
+  const remaining = _resolveInitialDuration(duration, randomFn)
 
   const statuses = battleState[target].statuses
 
@@ -85,10 +87,10 @@ export function tickStatuses(battleState, target) {
 
 // --- internal helpers ---
 
-function _resolveInitialDuration(duration) {
+function _resolveInitialDuration(duration, randomFn = Math.random) {
   if (duration === 'random') {
-    // in_review: 1–3 turns
-    return Math.floor(Math.random() * 3) + 1
+    // in_review: 1–3 turns — uses randomFn for reproducibility with seeded RNG
+    return Math.floor(randomFn() * 3) + 1
   }
   return duration
 }

--- a/tests/EncounterEngine.test.js
+++ b/tests/EncounterEngine.test.js
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest'
+import {
+  selectFromPool,
+  encounterChance,
+} from '../src/engine/EncounterEngine.js'
+
+// Stable seeds used across tests — values chosen to hit different pool buckets.
+// These are just integer seeds for the PRNG; we verify reproducibility not the
+// exact encounter ID (the PRNG output is deterministic, so the same seed will
+// always resolve to the same encounter — we just check the shape is correct).
+
+const VALID_ENCOUNTER_TYPES = ['incident', 'engineer']
+
+describe('selectFromPool', () => {
+  it('returns a valid encounter object shape', () => {
+    const result = selectFromPool('pipeline_pass', 42, 10)
+    expect(result).not.toBeNull()
+    expect(typeof result.enemyId).toBe('string')
+    expect(typeof result.encounterType).toBe('string')
+    expect(typeof result.domain).toBe('string')
+    expect(VALID_ENCOUNTER_TYPES).toContain(result.encounterType)
+  })
+
+  it('is deterministic — same seed + region + stepCount always returns same encounter', () => {
+    const r1 = selectFromPool('production_plains', 9999, 15)
+    const r2 = selectFromPool('production_plains', 9999, 15)
+    expect(r1).toEqual(r2)
+  })
+
+  it('different seeds return different (statistically varied) results', () => {
+    // Run 20 different seeds and check we get more than one unique enemy
+    const results = new Set()
+    for (let seed = 1; seed <= 20; seed++) {
+      const r = selectFromPool('production_plains', seed, 5)
+      results.add(r.enemyId)
+    }
+    expect(results.size).toBeGreaterThan(1)
+  })
+
+  it('returns null for unknown / empty region', () => {
+    expect(selectFromPool('nonexistent_region', 42, 5)).toBeNull()
+  })
+
+  it('returns null for localhost_town (all pools empty)', () => {
+    expect(selectFromPool('localhost_town', 42, 5)).toBeNull()
+  })
+
+  it('handles region with no cursed pool — redistributes weight to common/rare', () => {
+    // pipeline_pass has empty cursed pool; should still return valid encounter
+    const result = selectFromPool('pipeline_pass', 12, 5)
+    expect(result).not.toBeNull()
+    // Enemy should be from common or rare pool only
+    const commonIds = ['npm_install_hang', '503_error', 'failed_pipeline']
+    const rareIds   = ['merge_conflict', 'port_conflict']
+    const allowed   = [...commonIds, ...rareIds]
+    expect(allowed).toContain(result.enemyId)
+  })
+
+  it('can return a cursed encounter for regions with a cursed pool', () => {
+    // jira_dungeon has cursed: ['the_gantt_chart']
+    // Run many seeds to give cursed pool a chance to be selected
+    const results = new Set()
+    for (let seed = 1; seed <= 500; seed++) {
+      const r = selectFromPool('jira_dungeon', seed, 5)
+      if (r) results.add(r.enemyId)
+    }
+    expect(results).toContain('the_gantt_chart')
+  })
+
+  it('common pool is selected more often than rare (approximately 70:25 ratio)', () => {
+    // production_plains: common=['high_cpu','disk_full','503_error'], rare=['prod_incident','runaway_process'], cursed=['sev1_at_3am']
+    let commonCount = 0
+    let rareCount   = 0
+    let cursedCount = 0
+
+    const commonIds = new Set(['high_cpu', 'disk_full', '503_error'])
+    const rareIds   = new Set(['prod_incident', 'runaway_process'])
+    const cursedIds = new Set(['sev1_at_3am'])
+
+    for (let seed = 1; seed <= 1000; seed++) {
+      const r = selectFromPool('production_plains', seed, 5)
+      if (!r) continue
+      if (commonIds.has(r.enemyId)) commonCount++
+      else if (rareIds.has(r.enemyId)) rareCount++
+      else if (cursedIds.has(r.enemyId)) cursedCount++
+    }
+
+    const total = commonCount + rareCount + cursedCount
+    const commonRatio  = commonCount / total
+    const rareRatio    = rareCount   / total
+    const cursedRatio  = cursedCount / total
+
+    // Allow generous tolerance due to small sample size; just ensure ordering
+    expect(commonRatio).toBeGreaterThan(rareRatio)
+    expect(rareRatio).toBeGreaterThan(cursedRatio)
+
+    // Rough bounds — common ~70%, rare ~25%, cursed ~5%
+    expect(commonRatio).toBeGreaterThan(0.60)
+    expect(rareRatio).toBeGreaterThan(0.15)
+    expect(cursedRatio).toBeGreaterThan(0.01)
+  })
+
+  it('when cursed pool empty, common and rare cover 100% of weight', () => {
+    // pipeline_pass: cursed pool is empty
+    let commonCount = 0
+    let rareCount   = 0
+    const commonIds = new Set(['npm_install_hang', '503_error', 'failed_pipeline'])
+    const rareIds   = new Set(['merge_conflict', 'port_conflict'])
+
+    for (let seed = 1; seed <= 500; seed++) {
+      const r = selectFromPool('pipeline_pass', seed, 5)
+      if (!r) continue
+      if (commonIds.has(r.enemyId)) commonCount++
+      else if (rareIds.has(r.enemyId)) rareCount++
+    }
+
+    const total = commonCount + rareCount
+    // Expect ratio ~74:26 (70/95 ~ 0.737, 25/95 ~ 0.263)
+    const commonRatio = commonCount / total
+    expect(commonRatio).toBeGreaterThan(0.65)
+    expect(commonRatio).toBeLessThan(0.85)
+  })
+})
+
+describe('encounterChance', () => {
+  it('returns a number between 0 and 1', () => {
+    const chance = encounterChance(10, 42)
+    expect(chance).toBeGreaterThanOrEqual(0)
+    expect(chance).toBeLessThanOrEqual(1)
+  })
+
+  it('is deterministic — same stepCount + seed returns same value', () => {
+    expect(encounterChance(7, 100)).toBe(encounterChance(7, 100))
+  })
+
+  it('probability increases with stepCount (up to a cap)', () => {
+    // After more steps, should be more likely to encounter — check trend
+    const lowSteps  = encounterChance(1,  1)
+    const midSteps  = encounterChance(20, 1)
+    const highSteps = encounterChance(50, 1)
+    expect(highSteps).toBeGreaterThanOrEqual(midSteps)
+    expect(midSteps).toBeGreaterThanOrEqual(lowSteps)
+  })
+
+  it('returns 0 on step 0', () => {
+    expect(encounterChance(0, 1)).toBe(0)
+  })
+})

--- a/tests/StatusEngine.test.js
+++ b/tests/StatusEngine.test.js
@@ -1,0 +1,265 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  applyStatus,
+  tickStatuses,
+  isStatusActive,
+} from '../src/engine/StatusEngine.js'
+
+// Helper: build a minimal battleState with statuses for a given target
+function makeBattleState(playerStatuses = [], opponentStatuses = []) {
+  return {
+    player:   { statuses: playerStatuses },
+    opponent: { statuses: opponentStatuses },
+  }
+}
+
+// Helper: find status entry in battleState
+function getStatus(battleState, target, statusId) {
+  return battleState[target].statuses.find(s => s.id === statusId)
+}
+
+describe('isStatusActive', () => {
+  it('returns false when target has no statuses', () => {
+    const state = makeBattleState()
+    expect(isStatusActive(state, 'player', 'throttled')).toBe(false)
+  })
+
+  it('returns true when status is present with remaining duration > 0', () => {
+    const state = makeBattleState([{ id: 'throttled', remaining: 2 }])
+    expect(isStatusActive(state, 'player', 'throttled')).toBe(true)
+  })
+
+  it('returns false when status remaining is 0', () => {
+    const state = makeBattleState([{ id: 'throttled', remaining: 0 }])
+    expect(isStatusActive(state, 'player', 'throttled')).toBe(false)
+  })
+
+  it('returns true for permanent (duration -1) statuses', () => {
+    const state = makeBattleState([{ id: 'technical_debt', remaining: -1 }])
+    expect(isStatusActive(state, 'player', 'technical_debt')).toBe(true)
+  })
+
+  it('checks per-target independently', () => {
+    const state = makeBattleState(
+      [{ id: 'throttled', remaining: 2 }],  // player has throttled
+      [],                                    // opponent does not
+    )
+    expect(isStatusActive(state, 'player',   'throttled')).toBe(true)
+    expect(isStatusActive(state, 'opponent', 'throttled')).toBe(false)
+  })
+})
+
+describe('applyStatus', () => {
+  it('returns an array of BattleEvent objects', () => {
+    const state  = makeBattleState()
+    const events = applyStatus(state, 'player', 'throttled')
+    expect(Array.isArray(events)).toBe(true)
+    expect(events.length).toBeGreaterThan(0)
+  })
+
+  it('emits a status_apply event with correct shape', () => {
+    const state  = makeBattleState()
+    const events = applyStatus(state, 'player', 'throttled')
+    const applyEvt = events.find(e => e.type === 'status_apply')
+    expect(applyEvt).toBeDefined()
+    expect(applyEvt.target).toBe('player')
+    expect(applyEvt.value).toBe('throttled')
+  })
+
+  it('adds the status to battleState.player.statuses', () => {
+    const state = makeBattleState()
+    applyStatus(state, 'player', 'throttled')
+    expect(isStatusActive(state, 'player', 'throttled')).toBe(true)
+  })
+
+  it('adds status with correct duration for throttled (3)', () => {
+    const state = makeBattleState()
+    applyStatus(state, 'player', 'throttled')
+    const entry = getStatus(state, 'player', 'throttled')
+    expect(entry.remaining).toBe(3)
+  })
+
+  it('adds status with correct duration for cold_start (1)', () => {
+    const state = makeBattleState()
+    applyStatus(state, 'player', 'cold_start')
+    const entry = getStatus(state, 'player', 'cold_start')
+    expect(entry.remaining).toBe(1)
+  })
+
+  it('adds status with correct duration for deprecated (4)', () => {
+    const state = makeBattleState()
+    applyStatus(state, 'player', 'deprecated')
+    const entry = getStatus(state, 'player', 'deprecated')
+    expect(entry.remaining).toBe(4)
+  })
+
+  it('adds technical_debt with permanent duration (-1)', () => {
+    const state = makeBattleState()
+    applyStatus(state, 'player', 'technical_debt')
+    const entry = getStatus(state, 'player', 'technical_debt')
+    expect(entry.remaining).toBe(-1)
+  })
+
+  it('in_review receives a random duration between 1 and 3 inclusive', () => {
+    // Run 50 times to get coverage of the range; values must all be 1–3
+    for (let i = 0; i < 50; i++) {
+      const state = makeBattleState()
+      applyStatus(state, 'player', 'in_review')
+      const entry = getStatus(state, 'player', 'in_review')
+      expect(entry.remaining).toBeGreaterThanOrEqual(1)
+      expect(entry.remaining).toBeLessThanOrEqual(3)
+      expect(Number.isInteger(entry.remaining)).toBe(true)
+    }
+  })
+
+  it('stacking technical_debt adds a new stack entry rather than resetting', () => {
+    const state = makeBattleState()
+    applyStatus(state, 'player', 'technical_debt')
+    applyStatus(state, 'player', 'technical_debt')
+    const entries = state.player.statuses.filter(s => s.id === 'technical_debt')
+    expect(entries.length).toBe(2)
+  })
+
+  it('applying throttled again resets duration (refreshes)', () => {
+    const state = makeBattleState([{ id: 'throttled', remaining: 1 }])
+    applyStatus(state, 'player', 'throttled')
+    const entry = getStatus(state, 'player', 'throttled')
+    expect(entry.remaining).toBe(3)
+    // Only one entry — refreshed, not duplicated
+    const entries = state.player.statuses.filter(s => s.id === 'throttled')
+    expect(entries.length).toBe(1)
+  })
+
+  it('applies to opponent independently', () => {
+    const state = makeBattleState()
+    applyStatus(state, 'opponent', 'deprecated')
+    expect(isStatusActive(state, 'opponent', 'deprecated')).toBe(true)
+    expect(isStatusActive(state, 'player',   'deprecated')).toBe(false)
+  })
+
+  it('returns empty array for unknown statusId (no-op)', () => {
+    const state  = makeBattleState()
+    const events = applyStatus(state, 'player', 'nonexistent_status')
+    expect(events).toEqual([])
+  })
+})
+
+describe('tickStatuses', () => {
+  it('returns an array', () => {
+    const state  = makeBattleState()
+    const events = tickStatuses(state, 'player')
+    expect(Array.isArray(events)).toBe(true)
+  })
+
+  it('decrements remaining by 1 each tick for finite statuses', () => {
+    const state = makeBattleState([{ id: 'throttled', remaining: 3 }])
+    tickStatuses(state, 'player')
+    expect(getStatus(state, 'player', 'throttled').remaining).toBe(2)
+  })
+
+  it('emits status_tick events for active statuses', () => {
+    const state  = makeBattleState([{ id: 'deprecated', remaining: 4 }])
+    const events = tickStatuses(state, 'player')
+    const tickEvt = events.find(e => e.type === 'status_tick')
+    expect(tickEvt).toBeDefined()
+    expect(tickEvt.target).toBe('player')
+    expect(tickEvt.value).toBe('deprecated')
+  })
+
+  it('removes status when remaining reaches 0', () => {
+    const state = makeBattleState([{ id: 'cold_start', remaining: 1 }])
+    tickStatuses(state, 'player')
+    expect(state.player.statuses.find(s => s.id === 'cold_start')).toBeUndefined()
+  })
+
+  it('emits status_expired event when status expires', () => {
+    const state  = makeBattleState([{ id: 'cold_start', remaining: 1 }])
+    const events = tickStatuses(state, 'player')
+    const expiredEvt = events.find(e => e.type === 'status_expired')
+    expect(expiredEvt).toBeDefined()
+    expect(expiredEvt.target).toBe('player')
+    expect(expiredEvt.value).toBe('cold_start')
+  })
+
+  it('does NOT decrement technical_debt (permanent, duration -1)', () => {
+    const state = makeBattleState([{ id: 'technical_debt', remaining: -1 }])
+    tickStatuses(state, 'player')
+    const entry = getStatus(state, 'player', 'technical_debt')
+    expect(entry).toBeDefined()
+    expect(entry.remaining).toBe(-1)
+  })
+
+  it('technical_debt never expires', () => {
+    const state = makeBattleState([{ id: 'technical_debt', remaining: -1 }])
+    // Tick 10 times — should still be present
+    for (let i = 0; i < 10; i++) tickStatuses(state, 'player')
+    expect(isStatusActive(state, 'player', 'technical_debt')).toBe(true)
+  })
+
+  it('multiple statuses tick independently', () => {
+    const state = makeBattleState([
+      { id: 'throttled',  remaining: 3 },
+      { id: 'deprecated', remaining: 2 },
+    ])
+    tickStatuses(state, 'player')
+    expect(getStatus(state, 'player', 'throttled').remaining).toBe(2)
+    expect(getStatus(state, 'player', 'deprecated').remaining).toBe(1)
+  })
+
+  it('only ticks target statuses — opponent unaffected when ticking player', () => {
+    const state = makeBattleState(
+      [{ id: 'throttled', remaining: 3 }],
+      [{ id: 'throttled', remaining: 3 }],
+    )
+    tickStatuses(state, 'player')
+    expect(getStatus(state, 'player',   'throttled').remaining).toBe(2)
+    expect(getStatus(state, 'opponent', 'throttled').remaining).toBe(3)
+  })
+
+  it('after expiry the status is fully gone from statuses array', () => {
+    const state = makeBattleState([{ id: 'throttled', remaining: 1 }])
+    tickStatuses(state, 'player')
+    expect(state.player.statuses.length).toBe(0)
+  })
+
+  it('emits no events when statuses list is empty', () => {
+    const state  = makeBattleState()
+    const events = tickStatuses(state, 'player')
+    expect(events).toEqual([])
+  })
+})
+
+describe('status full lifecycle — apply then tick to expiry', () => {
+  it('throttled: apply → tick 3 times → expired', () => {
+    const state = makeBattleState()
+    applyStatus(state, 'player', 'throttled')
+    expect(isStatusActive(state, 'player', 'throttled')).toBe(true)
+
+    tickStatuses(state, 'player') // remaining: 2
+    expect(isStatusActive(state, 'player', 'throttled')).toBe(true)
+
+    tickStatuses(state, 'player') // remaining: 1
+    expect(isStatusActive(state, 'player', 'throttled')).toBe(true)
+
+    const events = tickStatuses(state, 'player') // remaining: 0 → expired
+    expect(isStatusActive(state, 'player', 'throttled')).toBe(false)
+    expect(events.some(e => e.type === 'status_expired')).toBe(true)
+  })
+
+  it('cold_start: apply → tick once → expired', () => {
+    const state = makeBattleState()
+    applyStatus(state, 'player', 'cold_start')
+    expect(isStatusActive(state, 'player', 'cold_start')).toBe(true)
+
+    const events = tickStatuses(state, 'player')
+    expect(isStatusActive(state, 'player', 'cold_start')).toBe(false)
+    expect(events.some(e => e.type === 'status_expired')).toBe(true)
+  })
+
+  it('technical_debt: apply → tick 100 times → still active', () => {
+    const state = makeBattleState()
+    applyStatus(state, 'player', 'technical_debt')
+    for (let i = 0; i < 100; i++) tickStatuses(state, 'player')
+    expect(isStatusActive(state, 'player', 'technical_debt')).toBe(true)
+  })
+})

--- a/tests/random.test.js
+++ b/tests/random.test.js
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest'
+import { seedRandom, randInt, randChoice } from '../src/utils/random.js'
+
+describe('seedRandom', () => {
+  it('returns a function', () => {
+    expect(typeof seedRandom(42)).toBe('function')
+  })
+
+  it('produces deterministic values — same seed always returns same sequence', () => {
+    const rand1 = seedRandom(42)
+    const rand2 = seedRandom(42)
+    const seq1 = [rand1(), rand1(), rand1(), rand1(), rand1()]
+    const seq2 = [rand2(), rand2(), rand2(), rand2(), rand2()]
+    expect(seq1).toEqual(seq2)
+  })
+
+  it('produces different values for different seeds', () => {
+    const rand1 = seedRandom(1)
+    const rand2 = seedRandom(2)
+    expect(rand1()).not.toBe(rand2())
+  })
+
+  it('returns floats in [0, 1) range', () => {
+    const rand = seedRandom(999)
+    for (let i = 0; i < 100; i++) {
+      const val = rand()
+      expect(val).toBeGreaterThanOrEqual(0)
+      expect(val).toBeLessThan(1)
+    }
+  })
+
+  it('produces reasonably uniform distribution — mean near 0.5 over many samples', () => {
+    const rand = seedRandom(12345)
+    let sum = 0
+    const N = 10000
+    for (let i = 0; i < N; i++) sum += rand()
+    const mean = sum / N
+    // Mean of uniform [0,1) is 0.5 — allow 2% tolerance
+    expect(mean).toBeGreaterThan(0.48)
+    expect(mean).toBeLessThan(0.52)
+  })
+
+  it('seed 0 is valid and deterministic', () => {
+    const rand1 = seedRandom(0)
+    const rand2 = seedRandom(0)
+    expect(rand1()).toBe(rand2())
+  })
+})
+
+describe('randInt', () => {
+  it('returns integers in [min, max)', () => {
+    const rand = seedRandom(7)
+    for (let i = 0; i < 200; i++) {
+      const val = randInt(rand, 0, 10)
+      expect(Number.isInteger(val)).toBe(true)
+      expect(val).toBeGreaterThanOrEqual(0)
+      expect(val).toBeLessThan(10)
+    }
+  })
+
+  it('is deterministic — same sequence for same initial seed', () => {
+    const rand1 = seedRandom(55)
+    const rand2 = seedRandom(55)
+    const vals1 = Array.from({ length: 5 }, () => randInt(rand1, 0, 100))
+    const vals2 = Array.from({ length: 5 }, () => randInt(rand2, 0, 100))
+    expect(vals1).toEqual(vals2)
+  })
+
+  it('handles single-item range (min === max-1)', () => {
+    const rand = seedRandom(1)
+    expect(randInt(rand, 5, 6)).toBe(5)
+  })
+})
+
+describe('randChoice', () => {
+  it('returns an element that exists in the array', () => {
+    const arr = ['a', 'b', 'c', 'd']
+    const rand = seedRandom(88)
+    for (let i = 0; i < 50; i++) {
+      expect(arr).toContain(randChoice(rand, arr))
+    }
+  })
+
+  it('is deterministic — same seed picks same element', () => {
+    const arr = ['linux', 'cloud', 'security', 'kubernetes']
+    const rand1 = seedRandom(100)
+    const rand2 = seedRandom(100)
+    expect(randChoice(rand1, arr)).toBe(randChoice(rand2, arr))
+  })
+
+  it('returns the only element when array has length 1', () => {
+    const rand = seedRandom(1)
+    expect(randChoice(rand, ['only'])).toBe('only')
+  })
+
+  it('covers all elements over enough samples', () => {
+    const arr = ['a', 'b', 'c']
+    const rand = seedRandom(321)
+    const seen = new Set()
+    for (let i = 0; i < 300; i++) seen.add(randChoice(rand, arr))
+    expect(seen).toEqual(new Set(['a', 'b', 'c']))
+  })
+})


### PR DESCRIPTION
Implements issue #9 — random encounters and status effects.

## Summary

### `src/utils/random.js` (new)
Seeded RNG using mulberry32 — deterministic, reproducible encounter rolls. Exports `seedRandom(seed)` (float 0–1), `randInt(min, max, seed)`, `randChoice(arr, seed)`. `Math.random()` is never used in encounter logic.

### `src/engine/EncounterEngine.js`
Pool-based encounter selection per region. Weights: common 70% / rare 25% / cursed 5%. Empty cursed pool redistributes weight proportionally (common 74%, rare 26%). `encounterChance(stepCount, seed)` ramps from 5% at step 1 by +1%/step, capped at 25%, returns 0 at step 0. Reads pool definitions from `src/data/encounters.js`.

### `src/engine/StatusEngine.js`
`applyStatus`, `tickStatuses`, `isStatusActive`. All statuses from `config.js` supported. `technical_debt` stacks independently (permanent, duration −1). All other statuses refresh on re-apply. `in_review` resolves its random 1–3 turn duration on apply.

### Tests (written first — TDD)
- **random.test.js**: 13 tests — determinism, range, uniform distribution
- **EncounterEngine.test.js**: 13 tests — pool weights, determinism, empty cursed fallback, null on unknown region
- **StatusEngine.test.js**: 31 tests — apply/tick/expire lifecycle, technical_debt stacking, permanent skip

57 new tests, all passing.

## Test plan
- [ ] `npm test` — all 57 new tests pass
- [ ] Same seed + stepCount always returns the same encounter
- [ ] Empty cursed pool → weight redistributed to common/rare only
- [ ] `technical_debt` never expires (duration −1)
- [ ] `tickStatuses` removes expired statuses and emits `status_expired` event

https://claude.ai/code/session_01RweSkEaRsCT3pSMCtg3TCJ